### PR TITLE
Add JSONP support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -393,6 +393,11 @@ uppercase.
 
 ``DOMAIN``                      A dict holding the API domain definition.
                                 See `Domain Configuration`_.
+
+``JSONP_ARGUMENT``              This option will cause the response to be
+                                wrapped in a JavaScript function call if the
+                                argument is set in the request.
+                                Defaults to ``None``
 =============================== =========================================
 
 .. _domain:

--- a/eve/render.py
+++ b/eve/render.py
@@ -127,9 +127,16 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
         # invoke the render function and obtain the corresponding rendered item
         rendered = globals()[renderer](dct)
 
-        # build the main wsgi rensponse object
-        resp = make_response(rendered, status)
-        resp.mimetype = mime
+    # JSONP
+    if "json" in mime:
+        jsonp_arg = config.JSONP_ARGUMENT
+        if jsonp_arg and jsonp_arg in request.args:
+            callback = request.args.get(jsonp_arg)
+            rendered = "%s(%s)" % (callback, rendered)
+
+    # build the main wsgi rensponse object
+    resp = make_response(rendered, status)
+    resp.mimetype = mime
 
     # cache directives
     if request.method in ('GET', 'HEAD'):

--- a/eve/tests/renders.py
+++ b/eve/tests/renders.py
@@ -77,6 +77,13 @@ class TestRenders(TestBase):
         r = self.test_client.get(self.known_resource_url)
         self.assertEqual(r.content_type, 'application/json')
 
+    def test_jsonp_enabled(self):
+        arg = "callback"
+        self.app.config['JSONP_ARGUMENT'] = arg
+        val = "JSON_CALLBACK"
+        r = self.test_client.get('/?%s=%s' % (arg, val))
+        self.assertTrue(r.get_data().startswith(val))
+
     def test_CORS(self):
         r = self.test_client.get('/')
         self.assertFalse('Access-Control-Allow-Origin' in r.headers)


### PR DESCRIPTION
I worked with a different JSON-API today which made me realise that Eve doesn't have support for JSONP yet. With this feature you're able to add a `JSONP_ARGUMENT` to your config. When you request a resource you can add this argument and the response will be wrapped in a JavaScript function call. The obviously only works with JSON. If XML is requested the setting is ignored.

Example

request: `curl -i http://localhost:5000/?callback=JSONP_CALLBACK`
response: `JSONP_CALLBACK( # json response here )`