### PR TITLE
Added serialization support for nested fields using dot notation.

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -312,8 +312,8 @@ def serialize(document, resource=None, schema=None, fields=None):
             elif '.' in field:
                 # handle nested "dot notation" field names (e.g. "a.b.c")
                 # todo: this code currently requires a schema for each part in
-                #       the dotted name, i.e. b must be in a's schema & c in b's
-                #       schema
+                #       the dotted name, i.e. b must be in a's schema & c in
+                #       b's schema
                 parts = field.split('.')
                 p_schema = schema
                 try:

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -309,6 +309,23 @@ def serialize(document, resource=None, schema=None, fields=None):
         for field in fields:
             if field in schema:
                 field_schema = schema[field]
+            elif '.' in field:
+                # handle nested "dot notation" field names (e.g. "a.b.c")
+                # todo: this code currently requires a schema for each part in
+                #       the dotted name, i.e. b must be in a's schema & c in b's
+                #       schema
+                parts = field.split('.')
+                p_schema = schema
+                try:
+                    for p in parts[:-1]:
+                        p_schema = p_schema[p]['schema']
+                    field_schema = p_schema[parts[-1]]
+                except KeyError:
+                    field_schema = None
+            else:
+                field_schema = None
+
+            if field_schema is not None:
                 field_type = field_schema.get('type')
                 if 'schema' in field_schema:
                     field_schema = field_schema['schema']

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -126,6 +126,14 @@ class TestPatch(TestBase):
         db_value = self.compare_patch_with_get(field, r)
         self.assertEqual(db_value, test_value)
 
+    def test_patch_nested(self):
+        field = "location.city"
+        test_value = 'a nested city'
+        changes = {field: test_value}
+        r = self.perform_patch(changes)
+        db_value = self.compare_patch_with_get("location", r)["city"]
+        self.assertEqual(db_value, test_value)
+
     def test_patch_datetime(self):
         field = "born"
         test_value = "Tue, 06 Nov 2012 10:33:31 GMT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cerberus==0.7.2
+Cerberus==0.8
 Events==0.2.1
 Flask-PyMongo==0.3.0
 Flask==0.10.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('LICENSE') as f:
     LICENSE = f.read()
 
 install_requires = [
-    'cerberus>=0.7,<0.8',
+    'cerberus>=0.7,<=0.8',
     'events>=0.2.1,<0.3',
     'simplejson>=3.3.0,<0.4',
     'werkzeug>=0.9.4,<0.10',


### PR DESCRIPTION
This change is to support PATCH commands containing updates to nested fields in subdocuments, using dot notation as in MongoDB. An example would be a PATCH like this:

```{"data.fan": "5435c2a4d302e926e818b2d5"}```

The idea is to traverse the schemas of each field in the dotted name to find the appropriate field_schema to use for serialization.