### PR TITLE
Fix bug when embedded is used on subdocument with missing field

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -538,7 +538,7 @@ def subdocuments(fields_chain, document):
     """
     if len(fields_chain) == 0:
         yield document
-    else:
+    elif fields_chain[0] in document:
         subdocument = document[fields_chain[0]]
         docs = subdocument if isinstance(subdocument, list) else [subdocument]
         for doc in docs:

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -653,6 +653,9 @@ class TestGet(TestBase):
         company = {'departments': [{'title': 'development',
                                    'members': contact_ids}]}
         company_id = _db.companies.insert(company)
+        # Add a documents with no reference that should be ignored
+        _db.companies.insert({})
+        _db.companies.insert({'departments': []})
 
         companies = self.domain['companies']
         contact_ids = list(map(str, contact_ids))


### PR DESCRIPTION
I've run into a bug when a get request is done with a embedded params on a missing subdocument

###### Example
Considering a request `GET http://api.lvh.me:8080/elements?projection={"tests.test": 1}`
If the `elements` collection contains an element which doesn't have a `tests` entry, the request is going to crash leading to a 500 response.
