### PR TITLE
Fix mongo Validator to work without transparent_schema_rules=True

### DIFF
--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -49,7 +49,7 @@ class Validator(Validator):
         self.resource = resource
         self._id = None
         self._original_document = None
-        super(Validator, self).__init__(schema, transparent_schema_rules=True)
+        super(Validator, self).__init__(schema)
         if resource:
             self.allow_unknown = config.DOMAIN[resource]['allow_unknown']
 
@@ -76,6 +76,16 @@ class Validator(Validator):
         """
         self._id = _id
         return super(Validator, self).validate(document)
+
+    def _validate_default(self, unique, field, value):
+        """ Fake validate function to let cerberus accept "default"
+            as keyword in the schema"""
+        pass
+
+    def _validate_versioned(self, unique, field, value):
+        """ Fake validate function to let cerberus accept "versioned"
+            as keyword in the schema"""
+        pass
 
     def _validate_unique(self, unique, field, value):
         """ Enables validation for `unique` schema attribute.

--- a/eve/tests/io/mongo.py
+++ b/eve/tests/io/mongo.py
@@ -107,7 +107,7 @@ class TestMongoValidator(TestCase):
     def test_transparent_rules(self):
         schema = {'a_field': {'type': 'string'}}
         v = Validator(schema)
-        self.assertTrue(v.transparent_schema_rules, True)
+        self.assertFalse(v.transparent_schema_rules)
 
     def test_geojson_not_compilant(self):
         schema = {'location': {'type': 'point'}}
@@ -253,7 +253,7 @@ class TestMongoValidator(TestCase):
         self.assertTrue(v.validate(doc))
 
         # With `dependencies` as a dict
-        schema['test_field'] = {'foo': 'foo', 'bar': 'bar'}
+        schema['test_field'] = {'dependencies': {'foo': 'foo', 'bar': 'bar'}}
         v = Validator(schema)
         self.assertTrue(v.validate(doc))
 


### PR DESCRIPTION
Hi,

I've found initializing mongo's Validator with `transparent_schema_rules=True` is  quite error-prone
For exemple considering a schema with a typo (`child_field` not enclosed in `{'type': 'dict', 'schema': {...}}`):
```
{
    'field': {
        'type': 'list',
        'schema': {
            'child_field': {'type': 'string'}
        }
    }
}
```
With `transparent_schema_rules=True` this schema is considered as valid and any arbitrary payload will be silently accepted !

This fix remove the need to use `transparent_schema_rules=True`... and fix a unittest whose invalid schema were silently failing, ouch ! ;-)
