### PR TITLE
Typo in exemple "Endpoint-level Authentication"?

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -102,7 +102,7 @@ resource-level ``authentication`` setting when we are defining the API
 
     DOMAIN = {
         'people': {
-            'authentication': MySuperCoolAuth,
+            'authentication': MySuperCoolAuth(),
             ...
             },
         'invoices': ... 


### PR DESCRIPTION
Is this a typo in the example ?
Doing as showed, give me:

```
node = {
    'authentication': NodeAuth,
[...]
}


TypeError: unbound method get_request_auth_value() must be called with NodeAuth instance as first argument (got nothing instead)
```

Adding parenthesis, fix the problem:
```
node = {
    'authentication': NodeAuth(),
[...]
}
