### PR TITLE
Add `X-Total-Count` header for collection GET response

### DIFF
--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -171,6 +171,8 @@ QUERY_PAGE = 'page'
 QUERY_MAX_RESULTS = 'max_results'
 QUERY_EMBEDDED = 'embedded'
 
+HEADER_TOTAL_COUNT = 'X-Total-Count'
+
 # user-restricted resource access is disabled by default.
 AUTH_FIELD = None
 

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -784,6 +784,9 @@ def pre_event(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         method = request_method()
+        if method == 'HEAD':
+            method = 'GET'
+
         event_name = 'on_pre_' + method
         resource = args[0] if args else None
         gh_params = ()
@@ -791,7 +794,7 @@ def pre_event(f):
         if method in ('GET', 'PATCH', 'DELETE', 'PUT'):
             gh_params = (resource, request, kwargs)
             rh_params = (request, kwargs)
-        elif method in ('POST'):
+        elif method in ('POST', ):
             # POST hook does not support the kwargs argument
             gh_params = (resource, request)
             rh_params = (request,)

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -106,10 +106,13 @@ def get(resource, **lookup):
             last_update = document[config.LAST_UPDATED]
 
     status = 200
+    headers = []
     last_modified = last_update if last_update > epoch() else None
 
     response[config.ITEMS] = documents
     count = cursor.count(with_limit_and_skip=False)
+    headers.append((config.HEADER_TOTAL_COUNT, count))
+
     if config.DOMAIN[resource]['hateoas']:
         response[config.LINKS] = _pagination_links(resource, req, count)
 
@@ -130,7 +133,7 @@ def get(resource, **lookup):
     if hasattr(cursor, 'extra'):
         getattr(cursor, 'extra')(response)
 
-    return response, last_modified, etag, status
+    return response, last_modified, etag, status, headers
 
 
 @ratelimit()

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -118,6 +118,16 @@ class TestGet(TestBase):
         self.assertTrue('next' not in links)
         self.assertTrue('prev' not in links)
 
+    def test_get_total_count_header(self):
+        url = self.domain[self.known_resource]['url']
+        r = self.test_client.head(url)
+        response, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertIsNone(response)
+
+        total_count = r.headers[self.app.config['HEADER_TOTAL_COUNT']]
+        self.assertEqual(int(total_count), self.known_resource_count)
+
     def test_get_where_mongo_syntax(self):
         where = '{"ref": "%s"}' % self.item_name
         response, status = self.get(self.known_resource, '?where=%s' % where)


### PR DESCRIPTION
Added custom header containing total count of items in response payload. This is handy for HEAD requests when user wants to know items count without retrieving response body.

A particular use case is to get the count of unread posts using `where` query without loading posts themselves.