### PR TITLE
For nicola/read only validation on replace

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Patches and Contributions
 - Arnau Orriols
 - Ashley Roach
 - Ben Demaree
+- Bjorn Andersson
 - Brian Mego
 - Bryan Cattle
 - boosh

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -68,7 +68,7 @@ class Validator(Validator):
         self._original_document = original_document
         return super(Validator, self).validate_update(document)
 
-    def validate_replace(self, document, _id):
+    def validate_replace(self, document, _id, original_document=None):
         """ Validation method to be invoked when performing a document
         replacement. This differs from :func:`validation_update` since in this
         case we want to perform a full :func:`validate` (the new document is to
@@ -79,6 +79,7 @@ class Validator(Validator):
         .. versionadded:: 0.1.0
         """
         self._id = _id
+        self._original_document = original_document
         return super(Validator, self).validate(document)
 
     def _validate_default(self, unique, field, value):

--- a/eve/methods/put.py
+++ b/eve/methods/put.py
@@ -132,7 +132,7 @@ def put_internal(resource, payload=None, concurrency_check=False,
         if skip_validation:
             validation = True
         else:
-            validation = validator.validate_replace(document, object_id)
+            validation = validator.validate_replace(document, object_id, original)
         if validation:
             # sneak in a shadow copy if it wasn't already there
             late_versioning_catch(original, resource)

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -433,6 +433,9 @@ class TestBase(TestMinimal):
 
                 'tid': ObjectId(),
             }
+            for child in schema:
+                if 'default' in schema[child]:
+                    contact[child] = schema[child]['default']
             if standard_date_fields:
                 contact[eve.LAST_UPDATED] = dt
                 contact[eve.DATE_CREATED] = dt

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -151,18 +151,24 @@ class TestPatch(TestBase):
         self.assertEqual(db_value, test_value)
 
     def test_patch_defaults(self):
+        schema = self.domain['contacts']['schema']
+
         field = "ref"
         test_value = "1234567890123456789012345"
         changes = {field: test_value}
         r = self.perform_patch(changes)
-        self.assertRaises(KeyError, self.compare_patch_with_get, 'title', r)
+        db_value = self.compare_patch_with_get('title', r)
+        self.assertEqual(db_value, schema['title']['default'])
 
     def test_patch_defaults_with_post_override(self):
+        schema = self.domain['contacts']['schema']
+
         field = "ref"
         test_value = "1234567890123456789012345"
         r, status_code = self.perform_patch_with_post_override(field, test_value)
         self.assert200(status_code)
-        self.assertRaises(KeyError, self.compare_patch_with_get, 'title', r)
+        db_value = self.compare_patch_with_get('title', r)
+        self.assertEqual(db_value, schema['title']['default'])
 
     def test_patch_multiple_fields(self):
         fields = ['ref', 'prog', 'role']

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -160,10 +160,9 @@ class TestPatch(TestBase):
     def test_patch_defaults_with_post_override(self):
         field = "ref"
         test_value = "1234567890123456789012345"
-        r = self.perform_patch_with_post_override(field, test_value)
-        self.assert200(r.status_code)
-        self.assertRaises(KeyError, self.compare_patch_with_get, 'title',
-                          json.loads(r.get_data()))
+        r, status_code = self.perform_patch_with_post_override(field, test_value)
+        self.assert200(status_code)
+        self.assertRaises(KeyError, self.compare_patch_with_get, 'title', r)
 
     def test_patch_multiple_fields(self):
         fields = ['ref', 'prog', 'role']
@@ -177,8 +176,8 @@ class TestPatch(TestBase):
 
     def test_patch_with_post_override(self):
         # a POST request with PATCH override turns into a PATCH request
-        r = self.perform_patch_with_post_override('prog', 1)
-        self.assert200(r.status_code)
+        r, status_code = self.perform_patch_with_post_override('prog', 1)
+        self.assert200(status_code)
 
     def test_patch_internal(self):
         # test that patch_internal is available and working properly.
@@ -215,9 +214,10 @@ class TestPatch(TestBase):
         headers = [('X-HTTP-Method-Override', 'PATCH'),
                    ('If-Match', self.item_etag),
                    ('Content-Type', 'application/json')]
-        return self.test_client.post(self.item_id_url,
+        r = self.test_client.post(self.item_id_url,
                                      data=json.dumps({field: value}),
                                      headers=headers)
+        return self.parse_response(r)
 
     def compare_patch_with_get(self, fields, patch_response):
         raw_r = self.test_client.get(self.item_id_url)

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -515,8 +515,6 @@ class TestPatch(TestBase):
         """
         # this will fail as dependent field is missing even in the
         # document we are trying to update.
-        del(self.domain['contacts']['schema']['dependency_field1']['default'])
-        del(self.domain['contacts']['defaults']['dependency_field1'])
         changes = {'dependency_field2': 'value'}
         r, status = self.patch(self.item_id_url, data=changes,
                                headers=[('If-Match', self.item_etag)])

--- a/eve/tests/methods/put.py
+++ b/eve/tests/methods/put.py
@@ -172,6 +172,23 @@ class TestPut(TestBase):
         db_value = self.compare_put_with_get(test_field, r)
         self.assertEqual(test_value, db_value)
 
+    def test_put_readonly_value_same(self):
+        data = {'ref': self.item['ref'],
+                'read_only_field': self.item['read_only_field']}
+        r, status = self.put(self.item_id_url,
+                             data=data,
+                             headers=[('If-Match', self.item_etag)])
+        self.assert200(status)
+
+    def test_put_readonly_value_different(self):
+        data = {'ref': self.item['ref'],
+                'read_only_field': 'somethingelse'}
+        r, status = self.put(self.item_id_url,
+                             data=data,
+                             headers=[('If-Match', self.item_etag)])
+        self.assert422(status)
+        self.assertValidationError(r, {'read_only_field': "field is read-only"})
+
     def test_put_subresource(self):
         _db = self.connection[MONGO_DBNAME]
 

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -89,7 +89,6 @@ contacts = {
         },
         'dependency_field1': {
             'type': 'string',
-            'default': 'default'
         },
         'dependency_field2': {
             'type': 'string',


### PR DESCRIPTION
This series of patches makes it possible to PUT an object with read-only properties, given that these keep their original values.