### PR TITLE
Fix item_lookup_field for versioned resources

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -238,8 +238,13 @@ def getitem(resource, **lookup):
 
     if version == 'all' or version == 'diffs':
         # find all versions
-        lookup[versioned_id_field()] = lookup[app.config['ID_FIELD']]
-        del lookup[app.config['ID_FIELD']]
+        item_lookup_field = \
+            app.config['DOMAIN'][resource].get('item_lookup_field')
+
+        if item_lookup_field == app.config['ID_FIELD']:
+            lookup[versioned_id_field()] = lookup[app.config['ID_FIELD']]
+            del lookup[app.config['ID_FIELD']]
+
         if version == 'diffs' or req.sort is None:
             # default sort for 'all', required sort for 'diffs'
             req.sort = '[("%s", 1)]' % config.VERSION

--- a/eve/versioning.py
+++ b/eve/versioning.py
@@ -252,8 +252,10 @@ def get_old_document(resource, req, lookup, document, version):
                 'Document version number should be an int greater than 0'
             ))
 
+        item_lookup_field = app.config["DOMAIN"][resource].get("item_lookup_field")
+
         # parameters to find specific document version
-        if versioned_id_field() not in lookup:
+        if versioned_id_field() not in lookup and item_lookup_field == "_id":
             lookup[versioned_id_field()] = lookup[app.config['ID_FIELD']]
             del lookup[app.config['ID_FIELD']]
         lookup[config.VERSION] = version

--- a/eve/versioning.py
+++ b/eve/versioning.py
@@ -252,10 +252,12 @@ def get_old_document(resource, req, lookup, document, version):
                 'Document version number should be an int greater than 0'
             ))
 
-        item_lookup_field = app.config["DOMAIN"][resource].get("item_lookup_field")
+        item_lookup_field = \
+            app.config["DOMAIN"][resource].get("item_lookup_field")
 
         # parameters to find specific document version
-        if versioned_id_field() not in lookup and item_lookup_field == "_id":
+        if (versioned_id_field() not in lookup and
+                item_lookup_field == app.config['ID_FIELD']):
             lookup[versioned_id_field()] = lookup[app.config['ID_FIELD']]
             del lookup[app.config['ID_FIELD']]
         lookup[config.VERSION] = version


### PR DESCRIPTION
See #524.

I don't know how the tests for this need to be implemented.
Would be great, if I could get some help there.

What I tested manually:
```python
...
VERSIONING = True
ITEM_URL = 'regex("[a-z0-9]{0,24}")'
DOMAIN = {
    'people' = {
        'item_lookup_field': 'lastname',
        'schema': {
            'firstname': {'type': 'string'},
            'lastname': {'type': 'string', 'required': True, 'unique': True}
        }
    }
}
```

```
GET /people/obama
GET /people/obama?version=1
GET /people/obama?version=diffs