### PR TITLE
fix(patch) - keep read-only fields when patching subdocuments

### DIFF
--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -204,7 +204,8 @@ class TestPatch(TestBase):
         self.assertTrue('Etag' in r.headers)
 
     def test_patch_nested(self):
-        changes = {'location': {'city': 'a nested city', 'address': 'a nested address'}}
+        changes = {'location': {'city': 'a nested city',
+                                'address': 'a nested address'}}
         r = self.perform_patch(changes)
         values = self.compare_patch_with_get('location', r)
         self.assertEqual(values['city'], 'a nested city')
@@ -456,7 +457,10 @@ class TestPatch(TestBase):
             r['test'],
             r['sensor']['dict']['int']
         )
+        self.assertEqual(test, 'default')
 
+        dict_schema = self.domain['sensors']['schema']['sensor']['schema']
+        dict_schema['dict']['schema']['int']['readonly'] = True
         changes = {
             'sensor': {
                 'lon': 10.0,
@@ -471,13 +475,11 @@ class TestPatch(TestBase):
         )
         self.assert200(status)
 
-        etag, value, int = (
+        etag, int = (
             r[ETAG],
-            r['sensor']['value'],
             r['sensor']['dict']['int']
         )
         self.assertEqual(value, 10.3)
-        self.assertEqual(test, 'default')
         self.assertEqual(int, 99)
 
     def test_patch_nested_document_nullable_missing(self):

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -203,6 +203,20 @@ class TestPatch(TestBase):
                                    headers=headers)
         self.assertTrue('Etag' in r.headers)
 
+    def test_patch_nested(self):
+        changes = {'location': {'city': 'a nested city', 'address': 'a nested address'}}
+        r = self.perform_patch(changes)
+        values = self.compare_patch_with_get('location', r)
+        self.assertEqual(values['city'], 'a nested city')
+        self.assertEqual(values['address'], 'a nested address')
+
+    def test_patch_nested_replaces_subdoc(self):
+        changes = {'location': {'city': 'a nested city'}}
+        r = self.perform_patch(changes)
+        values = self.compare_patch_with_get('location', r)
+        self.assertEqual(values['city'], 'a nested city')
+        self.assertTrue(values.get('address', None) is None)
+
     def perform_patch(self, changes):
         r, status = self.patch(self.item_id_url,
                                data=changes,


### PR DESCRIPTION
Replaces #587 