### PR TITLE
Geopoint decimal fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Patches and Contributions
 - Javier Gonel
 - Jean Boussier
 - Jen Montes
+- Joakim Uddholm
 - Joseph Heck
 - Johan Bloemberg
 - John Deng
@@ -71,7 +72,7 @@ Patches and Contributions
 - Matt Creenan
 - Mikael Berg
 - Niall Donegan
-- Nicolas Bazire
+- Nicolas Bazire2
 - Nicolas Carlier
 - Olivier Carrère
 - Olivier Poitrey

--- a/AUTHORS
+++ b/AUTHORS
@@ -72,7 +72,7 @@ Patches and Contributions
 - Matt Creenan
 - Mikael Berg
 - Niall Donegan
-- Nicolas Bazire2
+- Nicolas Bazire
 - Nicolas Carlier
 - Olivier Carrère
 - Olivier Poitrey

--- a/eve/io/mongo/geo.py
+++ b/eve/io/mongo/geo.py
@@ -10,11 +10,8 @@
     :license: BSD, see LICENSE for more details.
 """
 
-import sys
-
 
 class GeoJSON(dict):
-
     def __init__(self, json):
         try:
             self['type'] = json['type']
@@ -31,7 +28,6 @@ class GeoJSON(dict):
 
 
 class Geometry(GeoJSON):
-
     def __init__(self, json):
         super(Geometry, self).__init__(json)
         try:
@@ -43,21 +39,19 @@ class Geometry(GeoJSON):
 
 
 class GeometryCollection(GeoJSON):
-
     def __init__(self, json):
         super(GeometryCollection, self).__init__(json)
         try:
             if not isinstance(self['geometries'], list):
                 raise TypeError
             for geometry in self['geometries']:
-                factory = getattr(sys.modules[__name__], geometry["type"])
+                factory = factories[geometry["type"]]
                 factory(geometry)
         except (KeyError, TypeError, AttributeError):
             raise TypeError("Geometry not compilant to GeoJSON")
 
 
 class Point(Geometry):
-
     def __init__(self, json):
         super(Point, self).__init__(json)
         if not self._correct_position(self['coordinates']):
@@ -73,7 +67,6 @@ class MultiPoint(GeoJSON):
 
 
 class LineString(GeoJSON):
-
     def __init__(self, json):
         super(LineString, self).__init__(json)
         for position in self["coordinates"]:
@@ -82,7 +75,6 @@ class LineString(GeoJSON):
 
 
 class MultiLineString(GeoJSON):
-
     def __init__(self, json):
         super(MultiLineString, self).__init__(json)
         for linestring in self["coordinates"]:
@@ -92,7 +84,6 @@ class MultiLineString(GeoJSON):
 
 
 class Polygon(GeoJSON):
-
     def __init__(self, json):
         super(Polygon, self).__init__(json)
         for linestring in self["coordinates"]:
@@ -102,7 +93,6 @@ class Polygon(GeoJSON):
 
 
 class MultiPolygon(GeoJSON):
-
     def __init__(self, json):
         super(MultiPolygon, self).__init__(json)
         for polygon in self["coordinates"]:
@@ -110,3 +100,9 @@ class MultiPolygon(GeoJSON):
                 for position in linestring:
                     if not self._correct_position(position):
                         raise TypeError
+
+
+factories = dict([(_type.__name__, _type)
+                  for _type in
+                  [GeometryCollection, Point, MultiPoint, LineString,
+                  MultiLineString, Polygon, MultiPolygon]])

--- a/eve/io/mongo/geo.py
+++ b/eve/io/mongo/geo.py
@@ -25,8 +25,9 @@ class GeoJSON(dict):
             raise TypeError("Not compilant to GeoJSON")
 
     def _correct_position(self, position):
-        return isinstance(position, list) and isinstance(position[0], float) \
-            and isinstance(position[1], float)
+        return isinstance(position, list) and \
+            all(isinstance(pos, int) or isinstance(pos, float)
+                for pos in position)
 
 
 class Geometry(GeoJSON):

--- a/eve/tests/io/mongo.py
+++ b/eve/tests/io/mongo.py
@@ -148,6 +148,12 @@ class TestMongoValidator(TestCase):
         self.assertTrue('location' in v.errors)
         self.assertTrue('Point' in v.errors['location'])
 
+    def test_point_integer_success(self):
+        schema = {'location': {'type': 'point'}}
+        doc = {'location': {'type': "Point", 'coordinates': [10, 123.0]}}
+        v = Validator(schema)
+        self.assertTrue(v.validate(doc))
+
     def test_linestring_success(self):
         schema = {'location': {'type': 'linestring'}}
         doc = {'location': {"type": "LineString",

--- a/eve/tests/io/mongo.py
+++ b/eve/tests/io/mongo.py
@@ -246,6 +246,18 @@ class TestMongoValidator(TestCase):
         v = Validator(schema)
         self.assertTrue(v.validate(doc))
 
+    def test_geometrycollection_fail(self):
+        schema = {'locations': {'type': 'geometrycollection'}}
+        doc = {'locations': {'type': "GeometryCollection",
+                             "geometries": [{"type": "GeoJSON",
+                                             "badinput": "lolololololol"}]
+                             }
+               }
+        v = Validator(schema)
+        self.assertFalse(v.validate(doc))
+        self.assertTrue('locations' in v.errors)
+        self.assertTrue('GeometryCollection' in v.errors['locations'])
+
     def test_dependencies_with_defaults(self):
         schema = {
             'test_field': {'dependencies': 'foo'},


### PR DESCRIPTION
See #591 

Fixed by adding new test and allowing for integers in the validation typecheck.

One minor caveat is that integers will also be stored as integers and as such a different type in mongo.
However, querying still works fine. See screenshot below.

![2015-04-03-235836_681x513_scrot](https://cloud.githubusercontent.com/assets/298627/6989817/df1d5c62-da60-11e4-9eda-deee641dd66a.png)
