### PR TITLE
Overwrite embedded_fields settings by 0 in ?embedded-query

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -497,6 +497,7 @@ def resolve_embedded_fields(resource, req):
     .. versionadded:: 0.4
     """
     embedded_fields = []
+    non_embedded_fields = []
     if req.embedded:
         # Parse the embedded clause, we are expecting
         # something like:   '{"user":1}'

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -511,6 +511,8 @@ def resolve_embedded_fields(resource, req):
         try:
             embedded_fields = [k for k, v in client_embedding.items()
                                if v == 1]
+            non_embedded_fields = [k for k, v in client_embedding.items()
+                                   if v == 0]
         except AttributeError:
             # We got something other than a dict
             abort(400, description=debug_error_message(
@@ -518,8 +520,8 @@ def resolve_embedded_fields(resource, req):
             ))
 
     embedded_fields = list(
-        set(config.DOMAIN[resource]['embedded_fields']) |
-        set(embedded_fields))
+        (set(config.DOMAIN[resource]['embedded_fields']) |
+         set(embedded_fields)) - set(non_embedded_fields))
 
     # For each field, is the field allowed to be embedded?
     # Pick out fields that have a `data_relation` where `embeddable=True`

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -632,6 +632,22 @@ class TestGet(TestBase):
         content = json.loads(r.get_data())
         self.assertFalse('missing-field' in content['_items'][0])
 
+        # Test default fields to be embedded
+        invoices['embedded_fields'] = ['person']
+        r = self.test_client.get("%s/" % invoices['url'])
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertTrue('location' in content['_items'][0]['person'])
+
+        # Test that default fields are overwritten by ?embedded=...0
+        invoices['embedded_fields'] = ['person']
+        embedded = '{"person": 0}'
+        r = self.test_client.get("%s/%s" % (invoices['url'],
+                                            '?embedded=%s' % embedded))
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertFalse('location' in content['_items'][0]['person'])
+
     def test_get_custom_embedded(self):
         self.app.config['QUERY_EMBEDDED'] = 'included'
         # We need to assign a `person` to our test invoice
@@ -727,6 +743,16 @@ class TestGet(TestBase):
         content = json.loads(r.get_data())
         self.assertTrue('location' in
                         content['_items'][0]['departments'][0]['members'][0])
+
+        # Test that default fields are overwritten by ?embedded=...0
+        companies['embedded_fields'] = ["departments.members"]
+        embedded = '{"departments.members": 0}'
+        r = self.test_client.get('%s/%s' % (companies['url'],
+                                            '?embedded=%s' % embedded))
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertFalse('location' in
+                         content['_items'][0]['departments'][0]['members'][0])
 
     def test_get_nested_resource(self):
         response, status = self.get('users/overseas')

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -640,7 +640,6 @@ class TestGet(TestBase):
         self.assertTrue('location' in content['_items'][0]['person'])
 
         # Test that default fields are overwritten by ?embedded=...0
-        invoices['embedded_fields'] = ['person']
         embedded = '{"person": 0}'
         r = self.test_client.get("%s/%s" % (invoices['url'],
                                             '?embedded=%s' % embedded))
@@ -737,7 +736,7 @@ class TestGet(TestBase):
         self.assertTrue('location' in content['departments'][0]['members'][0])
 
         # Test default fields to be embedded
-        companies['embedded_fields'] = {"departments.members": 1}
+        companies['embedded_fields'] = ["departments.members"]
         r = self.test_client.get('%s/' % companies['url'])
         self.assert200(r.status_code)
         content = json.loads(r.get_data())
@@ -745,7 +744,6 @@ class TestGet(TestBase):
                         content['_items'][0]['departments'][0]['members'][0])
 
         # Test that default fields are overwritten by ?embedded=...0
-        companies['embedded_fields'] = ["departments.members"]
         embedded = '{"departments.members": 0}'
         r = self.test_client.get('%s/%s' % (companies['url'],
                                             '?embedded=%s' % embedded))


### PR DESCRIPTION
```python
'foobar': {
    embedded_fields = ["field1"],
    ...
}
```
A `GET .../foobar?embedded={"field1": 0}` now does not embed `field1`, so the query-setting is prioritized over the DOMAIN-setting.

This way we can have embedded fields by default and turn off the embedding at will by using the embedded-query.