### PR TITLE
Feature timezone

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ Patches and Contributions
 - Kracekumar
 - Kurt Bonne
 - Kurt Doherty
+- Lin, Wei-Hao
 - Magdas Adrian
 - Marc Abramowitz
 - Marcus Cobden

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -154,9 +154,15 @@ uppercase.
                                     stored as ``datetime`` values. In
                                     responses, ``datetime`` values will be
                                     rendered as JSON strings using this format.
-                                    Defaults to the RFC1123 (ex RFC 822)
-                                    standard ``a, %d %b %Y %H:%M:%S GMT``
-                                    ("Tue, 02 Apr 2013 10:29:13 GMT"). 
+                                    Defaults to ``a, %d %b %Y %H:%M:%S %Z``,
+                                    which is the RFC1123 (ex RFC 822)
+                                    standard ("Tue, 02 Apr 2013 10:29:13 GMT")
+                                    if ``DATE_TIMEZONE`` is not set. 
+
+``DATE_TIMEZONE``                   A string that representing the timezone used 
+                                    to parse and render datetime values. Allowed
+                                    values: see `List of tz database time zones <http://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
+                                    For example, ``Asia/Taipei``. Defaults to ``None``.
 
 ``RESOURCE_METHODS``                A list of HTTP methods supported at resource 
                                     endpoints. Allowed values: ``GET``,

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -162,7 +162,7 @@ uppercase.
 ``DATE_TIMEZONE``                   A string that representing the timezone used 
                                     to parse and render datetime values. Allowed
                                     values: see `List of tz database time zones <http://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
-                                    For example, ``Asia/Taipei``. Defaults to ``None``.
+                                    For example, ``Asia/Taipei``. Defaults to ``GMT``.
 
 ``RESOURCE_METHODS``                A list of HTTP methods supported at resource 
                                     endpoints. Allowed values: ``GET``,

--- a/eve/__init__.py
+++ b/eve/__init__.py
@@ -43,7 +43,7 @@ __version__ = '0.6-dev0'
 # RFC 1123 (ex RFC 822)
 DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %Z'
 RFC1123_DATE_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
-DATE_TIMEZONE = None
+DATE_TIMEZONE = 'GMT'
 
 URL_PREFIX = ''
 API_VERSION = ''

--- a/eve/__init__.py
+++ b/eve/__init__.py
@@ -41,8 +41,9 @@
 __version__ = '0.6-dev0'
 
 # RFC 1123 (ex RFC 822)
-DATE_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
+DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %Z'
 RFC1123_DATE_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
+DATE_TIMEZONE = None
 
 URL_PREFIX = ''
 API_VERSION = ''

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -86,7 +86,8 @@
 # DEBUG = True
 
 # RFC 1123 (ex RFC 822)
-DATE_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
+DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %Z'
+DATE_TIMEZONE = None
 
 STATUS_OK = "OK"
 STATUS_ERR = "ERR"

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -87,7 +87,7 @@
 
 # RFC 1123 (ex RFC 822)
 DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %Z'
-DATE_TIMEZONE = None
+DATE_TIMEZONE = 'GMT'
 
 STATUS_OK = "OK"
 STATUS_ERR = "ERR"

--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -20,7 +20,9 @@ class TestUtils(TestBase):
         super(TestUtils, self).setUp()
         self.dt_fmt = config.DATE_FORMAT
         self.datestr = 'Tue, 18 Sep 2012 10:12:30 GMT'
+        self.datestr_tz = 'Tue, 18 Sep 2012 18:12:30 CST'
         self.valid = datetime.strptime(self.datestr, self.dt_fmt)
+
         self.etag = '56eaadbbd9fa287e7270cf13a41083c94f52ab9b'
 
     def test_parse_request_where(self):
@@ -147,9 +149,12 @@ class TestUtils(TestBase):
 
     def test_str_to_date(self):
         self.assertEqual(str_to_date(self.datestr), self.valid)
+
+        config.DATE_TIMEZONE = 'Asia/Taipei'
+        self.assertEqual(str_to_date(self.datestr_tz), self.valid)
+        config.DATE_TIMEZONE = 'GMT'
+
         self.assertRaises(ValueError, str_to_date, 'not-a-date')
-        self.assertRaises(ValueError, str_to_date,
-                          self.datestr.replace('GMT', 'UTC'))
 
     def test_date_to_str(self):
         self.assertEqual(date_to_str(self.valid), self.datestr)

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -175,9 +175,6 @@ def str_to_date(string):
     """
     dt = datetime.strptime(string, config.DATE_FORMAT)
 
-    if not config.DATE_TIMEZONE:
-        return dt if string else None
-
     loc = pytz.timezone(config.DATE_TIMEZONE)
     gmt = pytz.timezone('GMT')
     
@@ -192,9 +189,6 @@ def date_to_str(date):
 
     :param date: the datetime value to convert.
     """
-    if not config.DATE_TIMEZONE:
-        return datetime.strftime(date, config.DATE_FORMAT) if date else None
-
     loc = pytz.timezone(config.DATE_TIMEZONE)
     gmt = pytz.timezone('GMT')
 

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -181,6 +181,8 @@ def str_to_date(string):
     dt_loc = loc.localize(dt)
     dt_gmt = dt_loc.astimezone(gmt)
 
+    dt_gmt = dt_gmt.replace(tzinfo=None)
+
     return dt_gmt if string else None
 
 

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -20,7 +20,7 @@ from flask import current_app as app
 from datetime import datetime, timedelta
 from bson.json_util import dumps
 from eve import RFC1123_DATE_FORMAT
-
+import pytz
 
 class Config(object):
     """ Helper class used through the code to access configuration settings.
@@ -173,7 +173,18 @@ def str_to_date(string):
 
     :param string: the RFC-1123 string to convert to datetime value.
     """
-    return datetime.strptime(string, config.DATE_FORMAT) if string else None
+    dt = datetime.strptime(string, config.DATE_FORMAT)
+
+    if not config.DATE_TIMEZONE:
+        return dt if string else None
+
+    loc = pytz.timezone(config.DATE_TIMEZONE)
+    gmt = pytz.timezone('GMT')
+    
+    dt_loc = loc.localize(dt)
+    dt_gmt = dt_loc.astimezone(gmt)
+
+    return dt_gmt if string else None
 
 
 def date_to_str(date):
@@ -181,7 +192,20 @@ def date_to_str(date):
 
     :param date: the datetime value to convert.
     """
-    return datetime.strftime(date, config.DATE_FORMAT) if date else None
+    if not config.DATE_TIMEZONE:
+        return datetime.strftime(date, config.DATE_FORMAT) if date else None
+
+    loc = pytz.timezone(config.DATE_TIMEZONE)
+    gmt = pytz.timezone('GMT')
+
+    try:
+        dt_gmt = gmt.localize(date)
+    except:
+        dt_gmt = date.astimezone(gmt)
+
+    dt_loc = dt_gmt.astimezone(loc)
+
+    return datetime.strftime(dt_loc, config.DATE_FORMAT) if date else None
 
 
 def date_to_rfc1123(date):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ MarkupSafe==0.23
 pymongo==2.7.2
 simplejson==3.6.5
 Werkzeug==0.10.1
+pytz==2015.2

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     'flask>=0.10.1,<0.11',
     'pymongo>=2.7.1,<3.0',
     'flask-pymongo>=0.3.0,<0.4',
+    'pytz>=2015.2'
 ]
 
 try:


### PR DESCRIPTION
Store datetime as GMT,  parse and render it as ``DATE_TIMEZONE`` in configuration. Use [pytz] (http://pytz.sourceforge.net/) to implement the feature, and it allow values in [List of tz database time zones] (http://en.wikipedia.org/wiki/List_of_tz_database_time_zones).