### PR TITLE
Apply Route Params to Documents Before Validation

### DIFF
--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -172,6 +172,7 @@ def post_internal(resource, payl=None, skip_validation=False):
         doc_issues = {}
         try:
             document = parse(value, resource)
+            resolve_sub_resource_path(document, resource)
             if skip_validation:
                 validation = True
             else:
@@ -183,7 +184,6 @@ def post_internal(resource, payl=None, skip_validation=False):
 
                 resolve_user_restricted_access(document, resource)
                 resolve_default_values(document, resource_def['defaults'])
-                resolve_sub_resource_path(document, resource)
                 store_media_files(document, resource)
                 resolve_document_version(document, resource, 'POST')
             else:

--- a/eve/tests/auth.py
+++ b/eve/tests/auth.py
@@ -151,6 +151,7 @@ class TestBasicAuth(TestBase):
             del(settings['public_methods'])
         self.app.set_defaults()
         del(domain['peopleinvoices'])
+        del(domain['peoplerequiredinvoices'])
         del(domain['peoplesearches'])
         del(domain['internal_transactions'])
         for resource in domain:

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -333,6 +333,7 @@ class TestConfig(TestBase):
         map_adapter = self.app.url_map.bind('')
 
         del(self.domain['peopleinvoices'])
+        del(self.domain['peoplerequiredinvoices'])
         del(self.domain['peoplesearches'])
         del(self.domain['internal_transactions'])
         for _, settings in self.domain.items():

--- a/eve/tests/endpoints.py
+++ b/eve/tests/endpoints.py
@@ -143,6 +143,7 @@ class TestEndPoints(TestBase):
 
     def test_resource_endpoint(self):
         del(self.domain['peopleinvoices'])
+        del(self.domain['peoplerequiredinvoices'])
         del(self.domain['peoplesearches'])
         del(self.domain['internal_transactions'])
         for settings in self.domain.values():

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -386,6 +386,18 @@ class TestPost(TestBase):
         self.assert200(status)
         self.assertEqual(response.get('person'), self.item_id)
 
+    def test_subresource_required_ref(self):
+        response, status = self.post('users/%s/required_invoices' %
+                                     self.item_id, data={})
+        self.assert201(status)
+        self.assertPostResponse(response)
+
+        invoice_id = response.get(self.app.config['ID_FIELD'])
+        response, status = self.get('users/%s/required_invoices/%s' %
+                                    (self.item_id, invoice_id))
+        self.assert200(status)
+        self.assertEqual(response.get('person'), self.item_id)
+
     def test_post_ifmatch_disabled(self):
         # if IF_MATCH is disabled, then we get no etag in the payload.
         self.app.config['IF_MATCH'] = False

--- a/eve/tests/renders.py
+++ b/eve/tests/renders.py
@@ -260,6 +260,7 @@ class TestRenders(TestBase):
                             self.app.config['API_VERSION'])
 
         del(self.domain['peopleinvoices'])
+        del(self.domain['peoplerequiredinvoices'])
         del(self.domain['peoplesearches'])
         del(self.domain['internal_transactions'])
         for _, settings in self.app.config['DOMAIN'].items():

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -155,6 +155,11 @@ invoices = {
 versioned_invoices = copy.deepcopy(invoices)
 versioned_invoices['versioning'] = True
 
+# This resource is used to test subresources that have a reference/objectid
+# field that is set to be required.
+required_invoices = copy.deepcopy(invoices)
+required_invoices['schema']['person']['required'] = True
+
 companies = {
     'item_title': 'company',
     'schema': {
@@ -196,6 +201,11 @@ users_invoices = copy.deepcopy(invoices)
 users_invoices['url'] = 'users/<regex("[a-f0-9]{24}"):person>/invoices'
 users_invoices['datasource'] = {'source': 'invoices'}
 
+users_required_invoices = copy.deepcopy(required_invoices)
+users_required_invoices['url'] =\
+    'users/<regex("[a-f0-9]{24}"):person>/required_invoices'
+users_required_invoices['datasource'] = {'source': 'required_invoices'}
+
 users_searches = copy.deepcopy(invoices)
 users_searches['datasource'] = {'source': 'invoices'}
 users_searches['url'] = \
@@ -223,10 +233,12 @@ DOMAIN = {
     'users_overseas': users_overseas,
     'invoices': invoices,
     'versioned_invoices': versioned_invoices,
+    'required_invoices': required_invoices,
     'payments': payments,
     'empty': empty,
     'restricted': user_restricted_access,
     'peopleinvoices': users_invoices,
+    'peoplerequiredinvoices': users_required_invoices,
     'peoplesearches': users_searches,
     'companies': companies,
     'internal_transactions': internal_transactions,


### PR DESCRIPTION
Route parameters are applied to new documents before they are validated.
This ensures that documents with required fields will be populated
before they are validated.

See nicolaiarocci/eve#354

---

Added a new test case to test the required field scenario.
All tests passed with both Python 2.7 and 3.4.

---

Pings:
@dexteradeus