### PR TITLE
make sure original is not modified during patch

### DIFF
--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -10,6 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
+from copy import deepcopy
 from flask import current_app as app, abort
 from werkzeug import exceptions
 from datetime import datetime
@@ -170,7 +171,7 @@ def patch_internal(resource, payload=None, concurrency_check=False,
             # etag, we're going to update the local version of the
             # 'original' document, and we will use it for the etag
             # computation.
-            updated = original.copy()
+            updated = deepcopy(original)
 
             # notify callbacks
             getattr(app, "on_update")(resource, updates, original)

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -121,9 +121,17 @@ class TestPatch(TestBase):
         field = "location"
         test_value = {'address': 'an address', 'city': 'a city'}
         changes = {field: test_value}
+        original_city = []
+
+        def keep_original_city(resource_name, updates, original):
+            original_city.append(original['location']['city'])
+
+        self.app.on_update += keep_original_city
+        self.app.on_updated += keep_original_city
         r = self.perform_patch(changes)
         db_value = self.compare_patch_with_get(field, r)
         self.assertEqual(db_value, test_value)
+        self.assertEqual(original_city[0], original_city[1])
 
     def test_patch_datetime(self):
         field = "born"


### PR DESCRIPTION
so that `on_update` and `on_updated` callbacks will get
same values

fix #611 