### PR TITLE
Invalidate cache when _latest_version changes in versioned doc.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,6 +75,7 @@ Patches and Contributions
 - Matthew Ellison
 - Mikael Berg
 - Niall Donegan
+- Nick Park
 - Nicolas Bazire
 - Nicolas Carlier
 - Olivier Carrère

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -690,15 +690,16 @@ update to the primary document) and uses that value to populate the
 validator of specific document version queries. Note that this will be
 different from the timestamp in the version's last updated field. The etag for
 a document version does not change when ```_latest_version``` changes, however.
-This results in two corner cases. First, a query using only ``If-None-Match``
-for cache validation will receive ``Not Modified``responses even when the
-cached ``_latest_version`` should be updated. Second, a version fetched and
-cached in the same second that multiple new versions are created can receive
-incorrect ``Not Modified`` responses on ensuing ``GET`` queries due to
-``Last-Modified`` values having a resolution of one second and the static etag
-values not providing indication of the changes. These are both highly unlikely
-scenarios, but an application expecting multiple edits per second should
-account for the possibility of holing stale ``_latest_version`` data.
+This results in two corner cases. First, because Eve cannot determine if the
+client's ```_latest_version``` is up to date from an ETag alone, a query using
+only ``If-None-Match`` for cache validation of old document versions will always
+have its cache invalidated. Second, a version fetched and cached in the same
+second that multiple new versions are created can receive incorrect
+``Not Modified`` responses on ensuing ``GET`` queries due to ``Last-Modified``
+values having a resolution of one second and the static etag values not
+providing indication of the changes. These are both highly unlikely scenarios,
+but an application expecting multiple edits per second should account for the
+possibility of holing stale ``_latest_version`` data.
 
 For more information see and :ref:`global` and :ref:`domain`.
 

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -240,10 +240,10 @@ def getitem(resource, **lookup):
         cache_valid = (last_modified <= req.if_modified_since)
         cache_validators[cache_valid] += 1
     if req.if_none_match:
-        # If-None-Match etag check important since Last-Modified dates have
-        # less than 1 second resolution
-        cache_valid = (etag == req.if_none_match)
-        cache_validators[cache_valid] += 1
+        if (resource_def['versioning'] is False) or \
+           (document['_version'] == document['_latest_version']):
+            cache_valid = (etag == req.if_none_match)
+            cache_validators[cache_valid] += 1
     # If all cache validators are true, return 304
     if (cache_validators[True] > 0) and (cache_validators[False] == 0):
         return {}, last_modified, etag, 304

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -209,11 +209,9 @@ def getitem(resource, **lookup):
     latest_doc = None
     cursor = None
 
-    # calculate last_modified and retrieve latest etag before get_old_document
-    # rolls back the document, allowing us to invalidate the cache when
-    # _latest_version changes
+    # calculate last_modified before get_old_document rolls back the document,
+    # allowing us to invalidate the cache when _latest_version changes
     last_modified = last_updated(document)
-    latest_etag = document.get(config.ETAG)
 
     # synthesize old document version(s)
     if resource_def['versioning'] is True:
@@ -223,23 +221,22 @@ def getitem(resource, **lookup):
 
     # meld into response document
     build_response_document(document, resource, embedded_fields, latest_doc)
-
-    # facilitate client caching by returning a 304 when appropriate
     if config.IF_MATCH:
         etag = document[config.ETAG]
-        if latest_etag is None and etag is not None:
-            latest_etag = etag
 
-        if req.if_none_match and latest_etag == req.if_none_match:
-            # request etag matches the current server representation of the
-            # document, return a 304 Not-Modified.
-            return {}, last_modified, document[config.ETAG], 304
-
-    if req.if_modified_since and last_modified <= req.if_modified_since:
-        # request If-Modified-Since conditional request match. We test
-        # this after the etag since Last-Modified dates have lower
-        # resolution (1 second).
-        return {}, last_modified, document.get(config.ETAG), 304
+    # facilitate client caching by returning a 304 when appropriate
+    cache_validators = {True: 0, False: 0}
+    if req.if_modified_since:
+        cache_valid = (last_modified <= req.if_modified_since)
+        cache_validators[cache_valid] += 1
+    if req.if_none_match:
+        # If-None-Match etag check important since Last-Modified dates have
+        # less than 1 second resolution
+        cache_valid = (etag == req.if_none_match)
+        cache_validators[cache_valid] += 1
+    # If all cache validators are true, return 304
+    if (cache_validators[True] > 0) and (cache_validators[False] == 0):
+        return {}, last_modified, etag, 304
 
     if version == 'all' or version == 'diffs':
         # find all versions

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -14,7 +14,7 @@ import copy
 import math
 from flask import current_app as app, abort, request
 from .common import ratelimit, epoch, pre_event, resolve_embedded_fields, \
-    build_response_document, resource_link, document_link
+    build_response_document, resource_link, document_link, last_updated
 from eve.auth import requires_auth
 from eve.utils import parse_request, home_link, querydef, config
 from eve.versioning import synthesize_versioned_document, versioned_id_field, \
@@ -209,6 +209,12 @@ def getitem(resource, **lookup):
     latest_doc = None
     cursor = None
 
+    # calculate last_modified and retrieve latest etag before get_old_document
+    # rolls back the document, allowing us to invalidate the cache when
+    # _latest_version changes
+    last_modified = last_updated(document)
+    latest_etag = document.get(config.ETAG)
+
     # synthesize old document version(s)
     if resource_def['versioning'] is True:
         latest_doc = copy.deepcopy(document)
@@ -218,14 +224,13 @@ def getitem(resource, **lookup):
     # meld into response document
     build_response_document(document, resource, embedded_fields, latest_doc)
 
-    # last_modified for the response
-    last_modified = document[config.LAST_UPDATED]
-
     # facilitate client caching by returning a 304 when appropriate
     if config.IF_MATCH:
         etag = document[config.ETAG]
+        if latest_etag is None and etag is not None:
+            latest_etag = etag
 
-        if req.if_none_match and etag == req.if_none_match:
+        if req.if_none_match and latest_etag == req.if_none_match:
             # request etag matches the current server representation of the
             # document, return a 304 Not-Modified.
             return {}, last_modified, document[config.ETAG], 304

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -224,6 +224,16 @@ def getitem(resource, **lookup):
     if config.IF_MATCH:
         etag = document[config.ETAG]
 
+    # check embedded fields resolved in build_response_document() for more
+    # recent last updated timestamps. We don't want to respond 304 if embedded
+    # fields have changed
+    for field in embedded_fields:
+        embedded_document = document.get(field)
+        if isinstance(embedded_document, dict):
+            embedded_last_updated = last_updated(embedded_document)
+            if embedded_last_updated > last_modified:
+                last_modified = embedded_last_updated
+
     # facilitate client caching by returning a 304 when appropriate
     cache_validators = {True: 0, False: 0}
     if req.if_modified_since:

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -417,7 +417,7 @@ class TestBase(TestMinimal):
         schema = DOMAIN['contacts']['schema']
         contacts = []
         for i in range(num):
-            dt = datetime.now()
+            dt = datetime.utcnow().replace(microsecond=0)
             contact = {
                 'ref': self.random_string(schema['ref']['maxlength']),
                 'prog': i,
@@ -450,7 +450,7 @@ class TestBase(TestMinimal):
     def random_payments(self, num):
         payments = []
         for i in range(num):
-            dt = datetime.now()
+            dt = datetime.utcnow().replace(microsecond=0)
             payment = {
                 'a_string': self.random_string(10),
                 'a_number': i,
@@ -463,7 +463,7 @@ class TestBase(TestMinimal):
     def random_invoices(self, num):
         invoices = []
         for _ in range(num):
-            dt = datetime.now()
+            dt = datetime.utcnow().replace(microsecond=0)
             invoice = {
                 'inv_number': self.random_string(10),
                 eve.LAST_UPDATED: dt,
@@ -497,7 +497,7 @@ class TestBase(TestMinimal):
     def random_internal_transactions(self, num):
         transactions = []
         for i in range(num):
-            dt = datetime.now()
+            dt = datetime.utcnow().replace(microsecond=0)
             transaction = {
                 'internal_string': self.random_string(10),
                 'internal_number': i,

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -202,8 +202,8 @@ class TestGet(TestBase):
         for role in ('agent', 'client', 'vendor'):
             where = 'role == %s' % role
             response, _ = self.get(self.known_resource, '?where=%s' % where)
-            if response['_meta']['max_results'] \
-                    >= self.app.config['PAGINATION_LIMIT'] + 1:
+            if response['_meta']['total'] \
+                    >= self.app.config['PAGINATION_DEFAULT'] + 1:
                 break
         links = response['_links']
         total = response['_meta']['total']

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -1101,6 +1101,25 @@ class TestGetItem(TestBase):
         content = json.loads(r.get_data())
         self.assertTrue('location' in content['person'])
 
+        # Test that changes to embedded document invalidate parent cache
+        invoice_last_modified = r.headers.get('Last-Modified')
+        contact_url = '%s/%s' % (self.domain['contacts']['url'],
+                                 fake_contact_id)
+        r = self.test_client.get(contact_url)
+        contact_etag = r.headers.get('Etag')
+
+        changes = {'location': {'city': 'new city'}}
+        response, status = self.patch(contact_url, data=changes,
+                                      headers=[('If-Match', contact_etag)])
+        self.assert200(status)
+
+        invoice_url = '%s/%s/%s' % (invoices['url'], self.invoice_id,
+                                    '?embedded=%s' % embedded)
+        r = self.test_client.get(invoice_url,
+                                 headers=[('If-Modified-Since',
+                                           invoice_last_modified)])
+        self.assert200(r.status_code)
+
     def test_subresource_getitem(self):
         _db = self.connection[MONGO_DBNAME]
 

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -1,4 +1,5 @@
 import base64
+import time
 from io import BytesIO
 import simplejson as json
 from datetime import datetime
@@ -1108,6 +1109,8 @@ class TestGetItem(TestBase):
         r = self.test_client.get(contact_url)
         contact_etag = r.headers.get('Etag')
 
+        # wait for contact and invoice updated at diff to pass 1s resolution
+        time.sleep(2)
         changes = {'location': {'city': 'new city'}}
         response, status = self.patch(contact_url, data=changes,
                                       headers=[('If-Match', contact_etag)])
@@ -1151,7 +1154,7 @@ class TestGetItem(TestBase):
 
         # IMS needs to see as recent as possible since the test db has just
         # been built
-        header = [("If-Modified-Since", date_to_rfc1123(datetime.now()))]
+        header = [("If-Modified-Since", date_to_rfc1123(datetime.utcnow()))]
 
         r = self.test_client.get(self.item_id_url, headers=header)
         self.assert304(r.status_code)

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -630,6 +630,20 @@ class TestCompleteVersioning(TestNormalVersioning):
         self.assert200(status)
         self.assertEqual(document[self.latest_version_field], 2)
 
+    def test_getitem_version_ignores_if_none_match(self):
+        """Verify that cached old version documents cannot be validated by
+        etag alone. It is impossible to catch _latest_version changes to old
+        versioned docs with only etags.
+        """
+        response, status = self.put(
+            self.item_id_url, data=self.item_change,
+            headers=[('If-Match', self.item_etag)])
+        self.assertGoodPutPatch(response, status)
+
+        r = self.test_client.get(self.item_id_url + "?version=1", headers=[
+            ('If-None-Match', self.item_etag)])
+        self.assert200(r.status_code)
+
     def test_automatic_fields(self):
         """ Make sure that Eve throws an error if we try to set a versioning
         field manually.


### PR DESCRIPTION
Closes #597.

The last modified and etag data from the latest document version
should be used when determining if a cached document version is
still valid. Otherwise, 304 Not Modified responses will be sent
when the _latest_version field has changed.