### PR TITLE
#608 Get support for declare and create mongodb indexes

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -834,6 +834,29 @@ always lowercase.
 
                                 See also: :ref:`authdrivendb`.
 
+``mongo_indexes``               Allows specify a set of indexes that have to
+                                created before the app is launched for this
+                                resource.
+
+                                Indexes are a dict where each value either
+                                takes a list of keys or the list of keys 
+                                plust the index options as one tuple, such
+                                as  ``{'index name': [('field', 1)],
+                                'index with args': ([('field', 1)],
+                                {"sparse": true})}``. 
+
+                                The list of keys take a (key, direction) pairs. 
+                                Multiple pairs are used to create compound
+                                indexes. The direction takes kind of values
+                                supported by `pymongo` such as ASCENDING = 1,
+                                DESCENDING = -1.
+
+                                Index arguments are index options supported 
+                                by `pymongo` such as sparce, min, max.
+
+                                Index already created before that have
+                                changed are removed and created again.
+
 ``authentication``              A class with the authorization logic for the 
                                 endpoint. If not provided the eventual
                                 general purpose auth class (passed as

--- a/eve/io/mongo/__init__.py
+++ b/eve/io/mongo/__init__.py
@@ -11,6 +11,6 @@
 """
 
 # flake8: noqa
-from eve.io.mongo.mongo import Mongo, MongoJSONEncoder
+from eve.io.mongo.mongo import Mongo, MongoJSONEncoder, create_index
 from eve.io.mongo.validation import Validator
 from eve.io.mongo.media import GridFSMediaStorage

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -11,6 +11,7 @@
 """
 import itertools
 from datetime import datetime
+from copy import copy
 
 import ast
 import pymongo
@@ -809,3 +810,75 @@ class PyMongos(dict):
         'self.data.driver.db[collection]' pattern.
         """
         return self.mongo.pymongo().db
+
+
+def create_index(app, resource, name, list_of_keys, index_options):
+    """ Create a specific index composed of the `list_of_keys` for the
+    mongo collection behind the `resource` using the `app.config`
+    to retrieve all data needed to find out the mongodb configuration.
+    The index is also configured by the `index_options`.
+
+    Index are a list of tuples setting for each one the name of the
+    fields and the kind of order used, 1 for ascending and -1 for
+    descending.
+
+    For example:
+        [('field_name', 1), ('other_field', -1)]
+
+    Other indexes such as "hash", "2d", "text" can be used.
+
+    Index options are a dictionary to set specific behaviour of the
+    index.
+
+    For example:
+        {"sparse": True}
+
+    .. versionadded:: 0.6
+    """
+    # it doesn't work as a typical mongodb method run in the request
+    # life cicle, it is just called when the app start and it uses
+    # pymongo directly.
+    collection = app.config['SOURCES'][resource]['source']
+    config_prefix = app.config['DOMAIN'][resource].get('mongo_prefix', 'MONGO')
+
+    def key(suffix):
+        return '%s_%s' % (config_prefix, suffix)
+
+    db_name = app.config[key('DBNAME')]
+
+    # just reproduced the same behaviour for username
+    # and password, the other fields come set by Eve by
+    # default.
+    username = app.config[key('USERNAME')]\
+        if key('USERNAME') in app.config else None
+    password = app.config[key('PASSWORD')]\
+        if key('PASSWORD') in app.config else None
+    host = app.config[key('HOST')]
+    port = app.config[key('PORT')]
+    auth = (username, password)
+    host_and_port = '%s:%s' % (host, port)
+    conn = pymongo.MongoClient(host_and_port)
+    db = conn[db_name]
+
+    if any(auth):
+        db.authenticate(username, password)
+
+    coll = db[collection]
+
+    kw = copy(index_options)
+    kw['name'] = name
+
+    try:
+        return coll.create_index(list_of_keys, **kw)
+    except pymongo.errors.OperationFailure as e:
+        if e.code == 85:
+            # This error is raised when the definition of the index has
+            # been changed, we didn't found any spec out there but we
+            # think tat this error is not going to change and we can trust.
+
+            # by default, drop the old index with old configuration and
+            # create the index againt with the new configuration
+            coll.drop_index(name)
+            return coll.create_index(list_of_keys, **kw)
+        else:
+            raise


### PR DESCRIPTION
Added a new config keyword called `mongo_indexes` that takes the list of keys that
belong to the index and also as optional the specific arguments of the index.