### PR TITLE
fix non serializable attributes in document_etag()

### DIFF
--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -177,7 +177,8 @@ class TestUtils(TestBase):
         ignore_fields = ["key2"]
         test_without_ignore = {'key1': 'value1'}
         challenge = dumps(test_without_ignore, sort_keys=True).encode('utf-8')
-        self.assertEqual(hashlib.sha1(challenge).hexdigest(),
+        with self.app.test_request_context():
+            self.assertEqual(hashlib.sha1(challenge).hexdigest(),
                          document_etag(test, ignore_fields))
 
         # not required fields can not be present
@@ -185,7 +186,8 @@ class TestUtils(TestBase):
         ignore_fields = ["key3"]
         test_without_ignore = {'key1': 'value1', 'key2': 'value2'}
         challenge = dumps(test_without_ignore, sort_keys=True).encode('utf-8')
-        self.assertEqual(hashlib.sha1(challenge).hexdigest(),
+        with self.app.test_request_context():
+            self.assertEqual(hashlib.sha1(challenge).hexdigest(),
                          document_etag(test, ignore_fields))
 
         # ignore fiels nested using doting notation
@@ -193,7 +195,8 @@ class TestUtils(TestBase):
         ignore_fields = ['dict.key2']
         test_without_ignore = {'key1': 'value1', 'dict': {'key3': 'value3'}}
         challenge = dumps(test_without_ignore, sort_keys=True).encode('utf-8')
-        self.assertEqual(hashlib.sha1(challenge).hexdigest(),
+        with self.app.test_request_context():
+            self.assertEqual(hashlib.sha1(challenge).hexdigest(),
                          document_etag(test, ignore_fields))
 
     def test_extract_key_values(self):

--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -168,8 +168,9 @@ class TestUtils(TestBase):
     def test_document_etag(self):
         test = {'key1': 'value1', 'another': 'value2'}
         challenge = dumps(test, sort_keys=True).encode('utf-8')
-        self.assertEqual(hashlib.sha1(challenge).hexdigest(),
-                         document_etag(test))
+        with self.app.test_request_context():
+            self.assertEqual(hashlib.sha1(challenge).hexdigest(),
+                             document_etag(test))
 
     def test_document_etag_ignore_fields(self):
         test = {'key1': 'value1', 'key2': 'value2'}

--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -179,7 +179,7 @@ class TestUtils(TestBase):
         challenge = dumps(test_without_ignore, sort_keys=True).encode('utf-8')
         with self.app.test_request_context():
             self.assertEqual(hashlib.sha1(challenge).hexdigest(),
-                         document_etag(test, ignore_fields))
+                             document_etag(test, ignore_fields))
 
         # not required fields can not be present
         test = {'key1': 'value1', 'key2': 'value2'}
@@ -188,7 +188,7 @@ class TestUtils(TestBase):
         challenge = dumps(test_without_ignore, sort_keys=True).encode('utf-8')
         with self.app.test_request_context():
             self.assertEqual(hashlib.sha1(challenge).hexdigest(),
-                         document_etag(test, ignore_fields))
+                             document_etag(test, ignore_fields))
 
         # ignore fiels nested using doting notation
         test = {'key1': 'value1', 'dict': {'key2': 'value2', 'key3': 'value3'}}
@@ -197,7 +197,7 @@ class TestUtils(TestBase):
         challenge = dumps(test_without_ignore, sort_keys=True).encode('utf-8')
         with self.app.test_request_context():
             self.assertEqual(hashlib.sha1(challenge).hexdigest(),
-                         document_etag(test, ignore_fields))
+                             document_etag(test, ignore_fields))
 
     def test_extract_key_values(self):
         test = {

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -297,7 +297,11 @@ def document_etag(value, ignore_fields=None):
         value_ = value
 
     h = hashlib.sha1()
-    h.update(dumps(value_, sort_keys=True).encode('utf-8'))
+    with app.app_context():
+        json_encoder = app.data.json_encoder_class()
+        h.update(
+            dumps(value, sort_keys=True,
+                  default=json_encoder.default).encode('utf-8'))
     return h.hexdigest()
 
 

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -300,7 +300,7 @@ def document_etag(value, ignore_fields=None):
     with app.app_context():
         json_encoder = app.data.json_encoder_class()
         h.update(
-            dumps(value, sort_keys=True,
+            dumps(value_, sort_keys=True,
                   default=json_encoder.default).encode('utf-8'))
     return h.hexdigest()
 


### PR DESCRIPTION
Hello,

This is an attempt to fix non serializable attributes (eg. timedelta)
even if we provide a custom json encoder to the underlying data driver (see RedTurtle/eve-sqlalchemy#37 for original issue).

Actually, I am not sure this is the best way to fix this issue since it needs to get the Flask app_context() but I did not find a cleaner way.

Also, I don't have any clue about the differences of generated etag by using `bson.json_util.default` or the `json_encoder_class.default`.
