### PR TITLE
Feat/soft delete

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -605,6 +605,10 @@ uppercase.
                                     has been deleted when ``SOFT_DELETE``
                                     is enabled. Defaults to ``_deleted``.
 
+``SHOW_DELETED_PARAM``              The URL query parameter used to include
+                                    soft deleted items in resource level GET
+                                    responses. Defaults to 'show_deleted'.
+
 =================================== =========================================
 
 .. _domain:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -597,6 +597,14 @@ uppercase.
                                     wrapped in a ``funcname`` call. Defaults to
                                     ``None``.
 
+``SOFT_DELETE``                     Enables soft delete when set to ``True``.
+                                    See :ref:`soft_delete` for more
+                                    information. Defaults to ``False``.
+
+``DELETED``                         Field name used to indicate if a document
+                                    has been deleted when ``SOFT_DELETE``
+                                    is enabled. Defaults to ``_deleted``.
+
 =================================== =========================================
 
 .. _domain:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -912,6 +912,10 @@ always lowercase.
                                 handled by the resource. Enables data
                                 validation. See `Schema Definition`_.
 
+``soft_delete``                 When ``True`` this option enables the
+                                :ref:`soft_delete` feature for this resource.
+                                Locally overrides ``SOFT_DELETE``.
+
 =============================== ===============================================
 
 Here's an example of resource customization, mostly done by overriding global

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -947,14 +947,13 @@ documents will add the ``_deleted`` field to the stored documents, set to
 ``false``.
 
 Responses to GET requests for soft deleted documents vary slightly from
-responses to missing or "hard" deleted documents. Instead of recieving a
-``404 Not Found`` response, GET requests for soft deleted documents will
-recieve a ``410 Gone`` response, indicating the document has been removed. The
+responses to missing or "hard" deleted documents. GET requests for soft deleted
+documents will still respond with ``404 Not Found`` status codes, but the
 response body will contain the soft deleted document with ``_deleted: true``.
 Documents embedded in the deleted document will not be expanded in the
 response, regardless of any default settings or the contents of the request's
 ``embedded`` query param. This is to ensure that soft deleted documents
-included in ``410 Gone`` responses reflect the state of a document when it was
+included in ``404`` responses reflect the state of a document when it was
 deleted, and do not to change if embedded documents are updated.
 
 By default, resource level GET requests will not include soft deleted items in
@@ -984,7 +983,7 @@ Versioning
 ~~~~~~~~~~
 Soft deleting a versioned document creates a new version of that document with
 ``_deleted`` set to ``true``. A GET request to the deleted version will recieve
-a ``410 Gone`` response as described above, while previous versions will
+a ``404 Not Found`` response as described above, while previous versions will
 continue to respond with ``200 OK``. Responses to ``?version=diff`` or
 ``?version=all`` will include the deleted version as if it were any other.
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -922,9 +922,11 @@ Soft Delete
 -----------
 Eve provides an optional "soft delete" mode in which deleted documents continue
 to be stored in the database and are able to be restored, but still act as
-removed items in response to API requests. Use of soft delete is controlled by
-the ``SOFT_DELETE`` configuration setting, and is disabled by default. See
-:ref:'global' for more information on enabling and configuring soft delete.
+removed items in response to API requests. Soft delete is disabled by default,
+but can be enabled globally using the ``SOFT_DELETE`` configuration setting, or
+individually configured at the resource level using the domain configuration
+``soft_delete`` setting. See :ref:'global' and :ref:'domain' for more
+information on enabling and configuring soft delete.
 
 Behavior
 ~~~~~~~~

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -689,9 +689,9 @@ update to the primary document) and uses that value to populate the
 ``Last-Modified`` header and check the ``If-Modified-Since`` conditional cache
 validator of specific document version queries. Note that this will be
 different from the timestamp in the version's last updated field. The etag for
-a document version does not change when ```_latest_version``` changes, however.
+a document version does not change when ``_latest_version`` changes, however.
 This results in two corner cases. First, because Eve cannot determine if the
-client's ```_latest_version``` is up to date from an ETag alone, a query using
+client's ``_latest_version`` is up to date from an ETag alone, a query using
 only ``If-None-Match`` for cache validation of old document versions will always
 have its cache invalidated. Second, a version fetched and cached in the same
 second that multiple new versions are created can receive incorrect
@@ -915,6 +915,91 @@ Document embedding is enabled by default.
     deciding whether to enable it or not, especially by default, keep in mind
     that each embedded resource being looked up will require a database lookup,
     which can easily lead to performance issues.
+
+.. _soft_delete:
+
+Soft Delete
+-----------
+Eve provides an optional "soft delete" mode in which deleted documents continue
+to be stored in the database and are able to be restored, but still act as
+removed items in response to API requests. Use of soft delete is controlled by
+the ``SOFT_DELETE`` configuration setting, and is disabled by default. See
+:ref:'global' for more information on enabling and configuring soft delete.
+
+Behavior
+~~~~~~~~
+With soft delete enabled, DELETE requests to individual items and resources
+respond just as they do for a traditional "hard" delete. Behind the scenes,
+however, Eve does not remove deleted items from the database, but instead
+patches the document with a ``_deleted`` field set to ``true``. (The name of
+the ``_deleted`` field is configurable. See :ref:'global'.) All requests made
+when soft delete is enabled filter against or otherwise account for the
+``_deleted`` field. Documents which have not been deleted will not define
+``_deleted`` in the database, but the field will still appear in response data
+for these items, automatically added and set to ``false`` by Eve.
+
+Responses to GET requests for soft deleted documents vary slightly from
+responses to missing or "hard" deleted documents. Instead of recieving a
+``404 Not Found`` response, GET requests for soft deleted documents will
+recieve a ``410 Gone`` response, indicating the document has been removed. The
+response body will contain the soft deleted document with ``_deleted: true``.
+Documents embedded in the deleted document will not be expanded in the
+response, regardless of any default settings or the contents of the request's
+``embedded`` query param. This is to ensure that soft deleted documents
+included in ``410 Gone`` responses reflect the state of a document when it was
+deleted, and do not to change if embedded documents are updated.
+
+By default, resource level GET requests will not include soft deleted items in
+their response. This behavior matches that of requests after a "hard" delete.
+If including deleted items in the response is desired, the ``show_deleted``
+query param can be added to the request. Eve will respond with all documents,
+deleted or not, and it is up to the client to parse returned documents'
+``_deleted`` field. The ``_deleted`` field can also be explicitly filtered
+against in a request, allowing only deleted documents to be returned using a
+``?where={"_deleted": true}`` query.
+
+Soft delete is enforced in the data layer, meaning queries made by application
+code using the ``app.data.find_one`` and ``app.data.find`` methods will
+automatically filter out soft deleted items. Passing a request object with
+``req.show_deleted == True`` or a lookup dictionary that explicitly filters on
+the ``_deleted`` field will override the default filtering.
+
+Restoring Soft Deleted Items
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Authorized PUT or PATCH requests made to a soft deleted document will restore
+it, setting ``_deleted`` to ``false`` in the database. The request must be made
+with proper authoriation for write permission to the soft deleted document or
+it will be refused.
+
+Versioning
+~~~~~~~~~~
+Soft deleting a versioned document creates a new version of that document with
+``_deleted`` set to ``true``. A GET request to the deleted version will recieve
+a ``410 Gone`` response as described above, while previous versions will
+continue to respond with ``200 OK``. Responses to ``?version=diff`` or
+``?version=all`` will include the deleted version as if it were any other.
+
+Data Relations
+~~~~~~~~~~~~~~
+The Eve ``data_relation`` validator will not allow references to documents that
+have been soft deleted. Attempting to create or update a document with a
+reference to a soft deleted document will fail just as if that document had
+been hard deleted. If the data relation is versioned, references to versions
+prior to of after restoration of the deleted version are allowed and will
+behave as expected. If a request requires expansion of an embedded document
+that has since been soft deleted, that document will resolve to a null value.
+
+Considerations
+~~~~~~~~~~~~~~
+Disabling soft delete after use in an application requires database maintenance
+to ensure your API remains consistent. With soft delete disabled, requests will
+no longer filter against or handle the ``_deleted`` field, and documents that
+were soft deleted will now be live again on your API. It is therefore necessary
+when disabling soft delete to perform a data migration to remove all documents
+with ``_deleted == True``, and recommended to remove the ``_deleted`` field
+from restored documents where ``_deleted == False`` is stored in the database.
+Enabling soft delete in an existing application is safe, and will maintain
+documents deleted from that point forward.
 
 .. _eventhooks:
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -960,10 +960,11 @@ deleted, and do not to change if embedded documents are updated.
 By default, resource level GET requests will not include soft deleted items in
 their response. This behavior matches that of requests after a "hard" delete.
 If including deleted items in the response is desired, the ``show_deleted``
-query param can be added to the request. Eve will respond with all documents,
-deleted or not, and it is up to the client to parse returned documents'
-``_deleted`` field. The ``_deleted`` field can also be explicitly filtered
-against in a request, allowing only deleted documents to be returned using a
+query param can be added to the request. (the ``show_deleted`` param name is
+configurable. See :ref:'global') Eve will respond with all documents, deleted
+or not, and it is up to the client to parse returned documents' ``_deleted``
+field. The ``_deleted`` field can also be explicitly filtered against in a
+request, allowing only deleted documents to be returned using a
 ``?where={"_deleted": true}`` query.
 
 Soft delete is enforced in the data layer, meaning queries made by application

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -17,6 +17,8 @@
        'RETURN_MEDIA_AS_URL' added and set to None.
        'MEDIA_ENDPOINT' added and set to 'media'.
        'MEDIA_URL' added and set to regex("[a-f0-9]{24}").
+       'SOFT_DELETE' added and set to False.
+       'DELETED' added and set to '_deleted'.
 
     .. versionchanged:: 0.5
        'SERVER_NAME' removed.
@@ -99,6 +101,7 @@ ITEMS = '_items'
 LINKS = '_links'
 ETAG = '_etag'
 VERSION = '_version'            # field that stores the version number
+DELETED = '_deleted'            # field to store soft delete status
 META = '_meta'
 
 VALIDATION_ERROR_STATUS = 422
@@ -138,6 +141,7 @@ VERSIONS = '_versions'          # suffix for parallel collection w/old versions
 VERSION_PARAM = 'version'       # URL param for specific version of a document.
 INTERNAL_RESOURCE = False       # resources are public by default.
 JSONP_ARGUMENT = None           # JSONP disabled by default.
+SOFT_DELETE = False             # soft delete disabled by default.
 
 OPLOG = False                   # oplog is disabled by default.
 OPLOG_NAME = 'oplog'            # default oplog resource name.

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -142,6 +142,7 @@ VERSION_PARAM = 'version'       # URL param for specific version of a document.
 INTERNAL_RESOURCE = False       # resources are public by default.
 JSONP_ARGUMENT = None           # JSONP disabled by default.
 SOFT_DELETE = False             # soft delete disabled by default.
+SHOW_DELETED_PARAM = 'show_deleted'
 
 OPLOG = False                   # oplog is disabled by default.
 OPLOG_NAME = 'oplog'            # default oplog resource name.

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -374,6 +374,9 @@ class Eve(Flask, Events):
             self.config['VERSION'],
             self.config['LATEST_VERSION'],
             self.config['ID_FIELD'] + self.config['VERSION_ID_SUFFIX']]
+        if self.config['SOFT_DELETE'] is True:
+            fields += [self.config['DELETED']]
+
         offenders = []
         for field in fields:
             if field in schema:
@@ -574,6 +577,8 @@ class Eve(Flask, Events):
                 projection[
                     self.config['ID_FIELD'] +
                     self.config['VERSION_ID_SUFFIX']] = 1
+            if self.config['SOFT_DELETE'] is True:
+                projection[self.config['DELETED']] = 1
 
         # 'defaults' helper set contains the names of fields with default
         # values in their schema definition.

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -367,14 +367,17 @@ class Eve(Flask, Events):
            Now collecting offending items in a list and inserting results into
            the exception message.
         """
+        resource_settings = self.config['DOMAIN'][resource]
+
         # ensure automatically handled fields aren't defined
         fields = [eve.DATE_CREATED, eve.LAST_UPDATED, eve.ETAG]
-        # TODO: only add the following checks if settings['versioning'] == True
-        fields += [
-            self.config['VERSION'],
-            self.config['LATEST_VERSION'],
-            self.config['ID_FIELD'] + self.config['VERSION_ID_SUFFIX']]
-        if self.config['SOFT_DELETE'] is True:
+
+        if resource_settings['versioning'] is True:
+            fields += [
+                self.config['VERSION'],
+                self.config['LATEST_VERSION'],
+                self.config['ID_FIELD'] + self.config['VERSION_ID_SUFFIX']]
+        if resource_settings['soft_delete'] is True:
             fields += [self.config['DELETED']]
 
         offenders = []
@@ -526,6 +529,7 @@ class Eve(Flask, Events):
         settings.setdefault('pagination', self.config['PAGINATION'])
         settings.setdefault('projection', self.config['PROJECTION'])
         settings.setdefault('versioning', self.config['VERSIONING'])
+        settings.setdefault('soft_delete', self.config['SOFT_DELETE'])
         settings.setdefault('internal_resource',
                             self.config['INTERNAL_RESOURCE'])
         settings.setdefault('etag_ignore_fields', None)
@@ -577,7 +581,7 @@ class Eve(Flask, Events):
                 projection[
                     self.config['ID_FIELD'] +
                     self.config['VERSION_ID_SUFFIX']] = 1
-            if self.config['SOFT_DELETE'] is True:
+            if settings['soft_delete'] is True:
                 projection[self.config['DELETED']] = 1
 
         # 'defaults' helper set contains the names of fields with default

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -557,7 +557,14 @@ class Eve(Flask, Events):
             # enable retrieval of actual schema fields only. Eventual db
             # fields not included in the schema won't be returned.
             projection = {}
+            projection.update(dict((field, 1) for (field) in schema))
+        else:
+            # all fields are returned.
+            projection = None
+        settings['datasource'].setdefault('projection', projection)
+        if settings['datasource']['projection']:
             # despite projection, automatic fields are always included.
+            projection = settings['datasource']['projection']
             projection[self.config['ID_FIELD']] = 1
             projection[self.config['LAST_UPDATED']] = 1
             projection[self.config['DATE_CREATED']] = 1
@@ -567,11 +574,6 @@ class Eve(Flask, Events):
                 projection[
                     self.config['ID_FIELD'] +
                     self.config['VERSION_ID_SUFFIX']] = 1
-            projection.update(dict((field, 1) for (field) in schema))
-        else:
-            # all fields are returned.
-            projection = None
-        settings['datasource'].setdefault('projection', projection)
 
         # 'defaults' helper set contains the names of fields with default
         # values in their schema definition.

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -214,9 +214,10 @@ class Mongo(DataLayer):
         if sub_resource_lookup:
             spec = self.combine_queries(spec, sub_resource_lookup)
 
-        if config.SOFT_DELETE and not req.show_deleted:
-            # Resolved after filter validation as querying against the DELETED
-            # must always be allowed when SOFT_DELETE is enabled
+        if config.DOMAIN[resource]['soft_delete'] and not req.show_deleted:
+            # Soft delete filtering applied after validate_filters call as
+            # querying against the DELETED field must always be allowed when
+            # soft_delete is enabled
             if not self.query_contains_field(spec, config.DELETED):
                 spec = self.combine_queries(
                     spec, {config.DELETED: {"$ne": True}})
@@ -283,10 +284,11 @@ class Mongo(DataLayer):
             lookup,
             client_projection)
 
-        if config.SOFT_DELETE and (not req or not req.show_deleted):
-            if not self.query_contains_field(lookup, config.DELETED):
-                filter_ = self.combine_queries(
-                    filter_, {config.DELETED: {"$ne": True}})
+        if (config.DOMAIN[resource]['soft_delete']) and \
+                (not req or not req.show_deleted) and \
+                (not self.query_contains_field(lookup, config.DELETED)):
+            filter_ = self.combine_queries(
+                filter_, {config.DELETED: {"$ne": True}})
 
         document = self.pymongo().db[datasource].find_one(filter_, projection)
         return document

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -113,6 +113,7 @@ class Mongo(DataLayer):
 
         .. versionchanged:: 0.6
            Support for multiple databases.
+           Filter soft deleted documents by default
 
         .. versionchanged:: 0.5
            Support for comma delimited sort syntax. Addresses #443.
@@ -216,8 +217,7 @@ class Mongo(DataLayer):
         if config.SOFT_DELETE and not req.show_deleted:
             # Resolved after filter validation as querying against the DELETED
             # must always be allowed when SOFT_DELETE is enabled
-            if (sub_resource_lookup is None) or \
-                    (config.DELETED not in sub_resource_lookup):
+            if not self.query_contains_field(spec, config.DELETED):
                 spec = self.combine_queries(
                     spec, {config.DELETED: {"$ne": True}})
 
@@ -255,6 +255,7 @@ class Mongo(DataLayer):
 
         .. versionchanged:: 0.6
            Support for multiple databases.
+           Filter soft deleted documents by default
 
         .. versionchanged:: 0.4
            Honor client projection requests.
@@ -283,7 +284,7 @@ class Mongo(DataLayer):
             client_projection)
 
         if config.SOFT_DELETE and (not req or not req.show_deleted):
-            if config.DELETED not in lookup:
+            if not self.query_contains_field(lookup, config.DELETED):
                 filter_ = self.combine_queries(
                     filter_, {config.DELETED: {"$ne": True}})
 

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -19,8 +19,7 @@ from bson import ObjectId
 from flask import current_app as app
 from cerberus import Validator
 from werkzeug.datastructures import FileStorage
-from eve.versioning import get_data_version_relation_document, \
-    missing_version_field
+from eve.versioning import get_data_version_relation_document
 from eve.io.mongo.geo import Point, MultiPoint, LineString, Polygon, \
     MultiLineString, MultiPolygon, GeometryCollection
 
@@ -161,17 +160,8 @@ class Validator(Validator):
                         " data_relation if '%s' isn't versioned" %
                         data_relation['resource'])
                 else:
-                    search = None
-
-                    # support late versioning
-                    if value[version_field] == 1:
-                        # there is a chance this document hasn't been saved
-                        # since versioning was turned on
-                        search = missing_version_field(data_relation, value)
-
-                    if not search:
-                        search = get_data_version_relation_document(
-                            data_relation, value)
+                    search = get_data_version_relation_document(
+                        data_relation, value)
 
                     if not search:
                         self._error(

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -55,10 +55,6 @@ def get_document(resource, concurrency_check, **lookup):
 
     document = app.data.find_one(resource, req, **lookup)
     if document:
-        if config.SOFT_DELETE and document.get(config.DELETED) is True:
-            # PUT, PATCH, and DELETE should not affect a soft deleted document
-            abort(410)
-
         if not req.if_match and config.IF_MATCH and concurrency_check:
             # we don't allow editing unless the client provides an etag
             # for the document

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -48,7 +48,7 @@ def get_document(resource, concurrency_check, **lookup):
       processing of new configuration settings: `filters`, `sorting`, `paging`.
     """
     req = parse_request(resource)
-    if config.SOFT_DELETE:
+    if config.DOMAIN[resource]['soft_delete']:
         # get_document should always fetch soft deleted documents from the db
         # They are handled with 410 responses below.
         req.show_deleted = True
@@ -477,7 +477,7 @@ def build_response_document(
     resolve_media_files(document, resource)
 
     # resolve soft delete
-    if config.SOFT_DELETE is True:
+    if config.DOMAIN[resource]['soft_delete'] is True:
         if document.get(config.DELETED) is None:
             document[config.DELETED] = False
         elif document[config.DELETED] is True:

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -30,11 +30,15 @@ def get_document(resource, concurrency_check, **lookup):
     the editing methods (PUT, PATCH, DELETE), we make sure that the client
     request references the current representation of the document before
     returning it. However, this concurrency control may be turned off by
-    internal functions.
+    internal functions. If resource enables soft delete, soft deleted documents
+    will be returned, and must be handled by callers.
 
     :param resource: the name of the resource to which the document belongs to.
     :param concurrency_check: boolean check for concurrency control
     :param **lookup: document lookup query
+
+    .. versionchanged:: 0.6
+        Return soft deleted documents.
 
     .. versionchanged:: 0.5
        Concurrency control optional for internal functions.
@@ -50,7 +54,7 @@ def get_document(resource, concurrency_check, **lookup):
     req = parse_request(resource)
     if config.DOMAIN[resource]['soft_delete']:
         # get_document should always fetch soft deleted documents from the db
-        # They are handled with 410 responses below.
+        # callers must handle soft deleted documents
         req.show_deleted = True
 
     document = app.data.find_one(resource, req, **lookup)

--- a/eve/methods/delete.py
+++ b/eve/methods/delete.py
@@ -83,6 +83,8 @@ def deleteitem_internal(
     # aborts with a 410 response
     if not original:
         abort(404)
+    elif config.SOFT_DELETE and original.get(config.DELETED) is True:
+        abort(410)
 
     # notify callbacks
     if suppress_callbacks is not True:

--- a/eve/methods/delete.py
+++ b/eve/methods/delete.py
@@ -47,6 +47,9 @@ def deleteitem_internal(
     :param concurrency_check: concurrency check switch (bool)
     :param **lookup: item lookup query.
 
+    .. versionchanged:: 0.6
+       Support for soft delete.
+
     .. versionchanged:: 0.5
        Return 204 NoContent instead of 200.
        Push updates to OpLog.
@@ -80,12 +83,9 @@ def deleteitem_internal(
     """
     soft_delete_enabled = config.DOMAIN[resource]['soft_delete']
     original = get_document(resource, concurrency_check, **lookup)
-    # If soft delete is enabled and document was already deleted, get_document
-    # aborts with a 410 response
-    if not original:
+    if not original or (soft_delete_enabled and
+                        original.get(config.DELETED) is True):
         abort(404)
-    elif soft_delete_enabled and original.get(config.DELETED) is True:
-        abort(410)
 
     # notify callbacks
     if suppress_callbacks is not True:

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -100,7 +100,7 @@ def get(resource, **lookup):
     req.if_modified_since = None
 
     cursor = app.data.find(resource, req, lookup)
-    # If SOFT_DELETE is enabled, data.find will not include items marked
+    # If soft delete is enabled, data.find will not include items marked
     # deleted unless req.show_deleted is True
     for document in cursor:
         build_response_document(document, resource, embedded_fields)
@@ -201,7 +201,8 @@ def getitem(resource, **lookup):
     resource_def = config.DOMAIN[resource]
     embedded_fields = resolve_embedded_fields(resource, req)
 
-    if config.SOFT_DELETE:
+    soft_delete_enabled = config.DOMAIN[resource]['soft_delete']
+    if soft_delete_enabled:
         # GET requests should always fetch soft deleted documents from the db
         # They are handled and included in 410 responses below.
         req.show_deleted = True
@@ -301,7 +302,7 @@ def getitem(resource, **lookup):
             response[config.ITEMS] = documents
         else:
             response = documents
-    elif config.SOFT_DELETE and document.get(config.DELETED) is True:
+    elif soft_delete_enabled and document.get(config.DELETED) is True:
         # This document was soft deleted. Respond with `410 Gone` and the
         # deleted version of the document.
         return document, last_modified, etag, 410

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -149,6 +149,9 @@ def getitem(resource, **lookup):
     :param resource: the name of the resource to which the document belongs.
     :param **lookup: the lookup query.
 
+    .. versionchanged:: 0.6
+       Handle soft deleted documents
+
     .. versionchanged:: 0.5
        Allow ``?version=all`` requests to fire ``on_fetched_*`` events.
        Create pagination links for document versions. (#475)
@@ -204,7 +207,7 @@ def getitem(resource, **lookup):
     soft_delete_enabled = config.DOMAIN[resource]['soft_delete']
     if soft_delete_enabled:
         # GET requests should always fetch soft deleted documents from the db
-        # They are handled and included in 410 responses below.
+        # They are handled and included in 404 responses below.
         req.show_deleted = True
 
     document = app.data.find_one(resource, req, **lookup)
@@ -303,9 +306,14 @@ def getitem(resource, **lookup):
         else:
             response = documents
     elif soft_delete_enabled and document.get(config.DELETED) is True:
-        # This document was soft deleted. Respond with `410 Gone` and the
-        # deleted version of the document.
-        return document, last_modified, etag, 410
+        # This document was soft deleted. Respond with 404 and the deleted
+        # version of the document.
+        document[config.STATUS] = config.STATUS_ERR,
+        document[config.ERROR] = {
+            'code': 404,
+            'message': 'The requested URL was not found on this server.'
+        }
+        return document, last_modified, etag, 404
     else:
         response = document
 

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -63,6 +63,9 @@ def patch_internal(resource, payload=None, concurrency_check=False,
     :param skip_validation: skip payload validation before write (bool)
     :param **lookup: document lookup query.
 
+    .. versionchanged:: 0.6
+       Allow restoring soft deleted documents via PATCH
+
     .. versionchanged:: 0.5
        Updating nested document fields does not overwrite the nested document
        itself (#519).

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -165,8 +165,10 @@ def patch_internal(resource, payload=None, concurrency_check=False,
             updates[config.LAST_UPDATED] = \
                 datetime.utcnow().replace(microsecond=0)
 
-            # Updates to a soft deleted document restore it
-            if config.SOFT_DELETE and original.get(config.DELETED) is True:
+            if config.SOFT_DELETE:
+                # PATCH with soft delete enabled should always set the DELETED
+                # field to False. We are either carrying through un-deleted
+                # status, or restoring a soft deleted document
                 updates[config.DELETED] = False
 
             # the mongo driver has a different precision than the python

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -165,7 +165,7 @@ def patch_internal(resource, payload=None, concurrency_check=False,
             updates[config.LAST_UPDATED] = \
                 datetime.utcnow().replace(microsecond=0)
 
-            if config.SOFT_DELETE:
+            if resource_def['soft_delete'] is True:
                 # PATCH with soft delete enabled should always set the DELETED
                 # field to False. We are either carrying through un-deleted
                 # status, or restoring a soft deleted document

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -165,6 +165,10 @@ def patch_internal(resource, payload=None, concurrency_check=False,
             updates[config.LAST_UPDATED] = \
                 datetime.utcnow().replace(microsecond=0)
 
+            # Updates to a soft deleted document restore it
+            if config.SOFT_DELETE and original.get(config.DELETED) is True:
+                updates[config.DELETED] = False
+
             # the mongo driver has a different precision than the python
             # datetime. since we don't want to reload the document once it
             # has been updated, and we still have to provide an updated

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -182,7 +182,7 @@ def post_internal(resource, payl=None, skip_validation=False):
                 document[config.LAST_UPDATED] = \
                     document[config.DATE_CREATED] = date_utc
 
-                if config.SOFT_DELETE is True:
+                if config.DOMAIN[resource]['soft_delete'] is True:
                     document[config.DELETED] = False
 
                 resolve_user_restricted_access(document, resource)

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -64,6 +64,9 @@ def post_internal(resource, payl=None, skip_validation=False):
                  discussion, and a typical use case.
     :param skip_validation: skip payload validation before write (bool)
 
+    .. versionchanged:: 0.6
+       Initialize DELETED field when soft_delete is enabled.
+
     .. versionchanged:: 0.5
        Back to resolving default values after validaton as now the validator
        can properly validate dependency even when some have default values. See

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -177,10 +177,13 @@ def post_internal(resource, payl=None, skip_validation=False):
                 validation = True
             else:
                 validation = validator.validate(document)
-            if validation:
-                # validation is successful
+            if validation:  # validation is successful
+                # Populate meta and default fields
                 document[config.LAST_UPDATED] = \
                     document[config.DATE_CREATED] = date_utc
+
+                if config.SOFT_DELETE is True:
+                    document[config.DELETED] = False
 
                 resolve_user_restricted_access(document, resource)
                 resolve_default_values(document, resource_def['defaults'])

--- a/eve/methods/put.py
+++ b/eve/methods/put.py
@@ -142,9 +142,10 @@ def put_internal(resource, payload=None, concurrency_check=False,
             last_modified = datetime.utcnow().replace(microsecond=0)
             document[config.LAST_UPDATED] = last_modified
             document[config.DATE_CREATED] = original[config.DATE_CREATED]
-
-            # updates to a soft deleted document restore it
-            if config.SOFT_DELETE and document.get(config.DELETED) is True:
+            if config.SOFT_DELETE:
+                # PUT with soft delete enabled should always set the DELETED
+                # field to False. We are either carrying through un-deleted
+                # status, or restoring a soft deleted document
                 document[config.DELETED] = False
 
             # ID_FIELD not in document means it is not being automatically

--- a/eve/methods/put.py
+++ b/eve/methods/put.py
@@ -143,6 +143,10 @@ def put_internal(resource, payload=None, concurrency_check=False,
             document[config.LAST_UPDATED] = last_modified
             document[config.DATE_CREATED] = original[config.DATE_CREATED]
 
+            # updates to a soft deleted document restore it
+            if config.SOFT_DELETE and document.get(config.DELETED) is True:
+                document[config.DELETED] = False
+
             # ID_FIELD not in document means it is not being automatically
             # handled (it has been set to a field which exists in the
             # resource schema.

--- a/eve/methods/put.py
+++ b/eve/methods/put.py
@@ -63,6 +63,9 @@ def put_internal(resource, payload=None, concurrency_check=False,
     :param skip_validation: skip payload validation before write (bool)
     :param **lookup: document lookup query.
 
+    .. versionchanged:: 0.6
+       Allow restoring soft deleted documents via PUT
+
     .. versionchanged:: 0.5
        Back to resolving default values after validaton as now the validator
        can properly validate dependency even when some have default values. See

--- a/eve/methods/put.py
+++ b/eve/methods/put.py
@@ -142,7 +142,7 @@ def put_internal(resource, payload=None, concurrency_check=False,
             last_modified = datetime.utcnow().replace(microsecond=0)
             document[config.LAST_UPDATED] = last_modified
             document[config.DATE_CREATED] = original[config.DATE_CREATED]
-            if config.SOFT_DELETE:
+            if resource_def['soft_delete'] is True:
                 # PUT with soft delete enabled should always set the DELETED
                 # field to False. We are either carrying through un-deleted
                 # status, or restoring a soft deleted document

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -105,9 +105,6 @@ class TestMinimal(unittest.TestCase):
     def assert404(self, status):
         self.assertEqual(status, 404)
 
-    def assert410(self, status):
-        self.assertEqual(status, 410)
-
     def assert422(self, status):
         self.assertEqual(status, 422)
 

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -99,11 +99,14 @@ class TestMinimal(unittest.TestCase):
     def assert301(self, status):
         self.assertEqual(status, 301)
 
+    def assert304(self, status):
+        self.assertEqual(status, 304)
+
     def assert404(self, status):
         self.assertEqual(status, 404)
 
-    def assert304(self, status):
-        self.assertEqual(status, 304)
+    def assert410(self, status):
+        self.assertEqual(status, 410)
 
     def assert422(self, status):
         self.assertEqual(status, 422)

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -67,6 +67,8 @@ class TestConfig(TestBase):
 
         self.assertEqual(self.app.config['JSON_SORT_KEYS'], False)
         self.assertEqual(self.app.config['SOFT_DELETE'], False)
+        self.assertEqual(self.app.config['DELETED'], '_deleted')
+        self.assertEqual(self.app.config['SHOW_DELETED_PARAM'], 'show_deleted')
 
     def test_settings_as_dict(self):
         my_settings = {'API_VERSION': 'override!', 'DOMAIN': {'contacts': {}}}

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -209,6 +209,8 @@ class TestConfig(TestBase):
                          self.app.config['ALLOWED_FILTERS'])
         self.assertEqual(settings['projection'], self.app.config['PROJECTION'])
         self.assertEqual(settings['versioning'], self.app.config['VERSIONING'])
+        self.assertEqual(settings['soft_delete'],
+                         self.app.config['SOFT_DELETE'])
         self.assertEqual(settings['sorting'], self.app.config['SORTING'])
         self.assertEqual(settings['embedding'], self.app.config['EMBEDDING'])
         self.assertEqual(settings['pagination'], self.app.config['PAGINATION'])

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -66,6 +66,7 @@ class TestConfig(TestBase):
         self.assertEqual(self.app.config['QUERY_EMBEDDED'], 'embedded')
 
         self.assertEqual(self.app.config['JSON_SORT_KEYS'], False)
+        self.assertEqual(self.app.config['SOFT_DELETE'], False)
 
     def test_settings_as_dict(self):
         my_settings = {'API_VERSION': 'override!', 'DOMAIN': {'contacts': {}}}

--- a/eve/tests/methods/delete.py
+++ b/eve/tests/methods/delete.py
@@ -3,6 +3,8 @@ from eve.tests.utils import DummyEvent
 from eve.tests.test_settings import MONGO_DBNAME
 from eve import ETAG
 from bson import ObjectId
+from eve.utils import ParsedRequest
+import copy
 
 from eve.methods.delete import deleteitem_internal
 
@@ -183,6 +185,291 @@ class TestDelete(TestBase):
     def delete(self, url, headers=None):
         r = self.test_client.delete(url, headers=headers)
         return self.parse_response(r)
+
+
+class TestSoftDelete(TestDelete):
+    def setUp(self):
+        super(TestSoftDelete, self).setUp()
+
+        # Enable soft delete
+        self.app.config['SOFT_DELETE'] = True
+        domain = copy.copy(self.domain)
+        for resource, settings in domain.items():
+            # rebuild resource settings for soft delete
+            self.app.register_resource(resource, settings)
+
+        # alias for the configured DELETED field name
+        self.DELETED = self.app.config['DELETED']
+
+    # TestDelete overrides
+
+    def test_delete(self):
+        """Soft delete should mark an item as deleted and cause subsequent
+        requests to return 410 Gone responses. 410s sent in response to GET
+        requests should include the document in their body with the _deleted
+        flag set to True.
+        """
+        r, status = self.delete(self.item_id_url, headers=self.etag_headers)
+        self.assert204(status)
+
+        r = self.test_client.get(self.item_id_url)
+        data, status = self.parse_response(r)
+        self.assert410(status)
+
+        self.assertEqual(data.get(self.DELETED), True)
+        self.assertNotEqual(data.get('_etag'), self.item_etag)
+
+    def test_deleteitem_internal(self):
+        """Deleteitem internal should honor soft delete settings.
+        """
+        # test that deleteitem_internal is available and working properly.
+        with self.app.test_request_context(self.item_id_url):
+            r, _, _, status = deleteitem_internal(
+                self.known_resource, concurrency_check=False,
+                **{'_id': self.item_id})
+        self.assert204(status)
+
+        r = self.test_client.get(self.item_id_url)
+        data, status = self.parse_response(r)
+        self.assert410(status)
+        self.assertEqual(data.get(self.DELETED), True)
+
+    def test_delete_different_resource(self):
+        r, status = self.delete(self.user_id_url,
+                                headers=[('If-Match', self.user_etag)])
+        self.assert204(status)
+
+        r = self.test_client.get(self.user_id_url)
+        data, status = self.parse_response(r)
+        self.assert410(status)
+        self.assertEqual(data.get(self.DELETED), True)
+
+    def test_delete_from_resource_endpoint(self):
+        """Soft deleting an entire resource should mark each individual item
+        as deleted, queries to that resource should return no items, and GETs
+        on any individual items should return 410 responses.
+        """
+        # TestDelete deletes resource at known_resource_url, and confirms
+        # subsequent queries to the resource return zero items
+        super(TestSoftDelete, self).test_delete_from_resource_endpoint()
+
+        r = self.test_client.get(self.item_id_url)
+        data, status = self.parse_response(r)
+        self.assert410(status)
+        self.assertEqual(data.get(self.DELETED), True)
+
+    # TetsSoftDelete specific tests
+
+    def test_operations_after_softdelete(self):
+        """After an item has been soft deleted, PUTs, PATCHes, and DELETEs should
+        return a 410 Gone response.
+        """
+        r, status = self.delete(self.item_id_url, headers=self.etag_headers)
+        self.assert204(status)
+
+        # PUT should return 410 Gone
+        r = self.test_client.put(self.item_id_url,
+                                 data={'ref': '1234567890123456789012345'},
+                                 headers=self.etag_headers)
+        self.assert410(r.status_code)
+
+        # PATCH should return 410 Gone
+        r = self.test_client.patch(self.item_id_url,
+                                   data={'ref': '1234567890123456789012345'},
+                                   headers=self.etag_headers)
+        self.assert410(r.status_code)
+
+        # Second soft DELETE should return 410 Gone
+        r, status = self.delete(self.item_id_url, headers=self.etag_headers)
+        self.assert410(status)
+
+    def test_softdelete_deleted_field(self):
+        """The configured 'deleted' field should be added to all documents to indicate
+        whether that document has been soft deleted or not.
+        """
+        r = self.test_client.get(self.item_id_url)
+        data, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertEqual(data.get(self.DELETED), False)
+
+    def test_softdelete_show_deleted(self):
+        """GETs on resource endpoints should include soft deleted items when
+        the 'show_deleted' param is included in the query
+        """
+        r, status = self.delete(self.item_id_url, headers=self.etag_headers)
+        self.assert204(status)
+
+        data, status = self.get(self.known_resource)
+        after_softdelete_count = data[self.app.config['META']]['total']
+        self.assertEqual(after_softdelete_count, self.known_resource_count - 1)
+
+        data, status = self.get(self.known_resource, query="?show_deleted")
+        show_deleted_count = data[self.app.config['META']]['total']
+        self.assertEqual(show_deleted_count, self.known_resource_count)
+
+        # Test show_deleted with additional queries
+        role_query = '?where={"role": "' + self.item['role'] + '"}'
+        data, status = self.get(self.known_resource, query=role_query)
+        role_count = data[self.app.config['META']]['total']
+
+        data, status = self.get(
+            self.known_resource, query=role_query + "&show_deleted")
+        show_deleted_role_count = data[self.app.config['META']]['total']
+        self.assertEqual(show_deleted_role_count, role_count + 1)
+
+    def test_softdeleted_embedded_doc(self):
+        """Soft deleted documents embedded in other documents should not be
+        included. They will resolve to None as if the document was actually
+        deleted.
+        """
+        # Set up and confirm embedded document
+        _db = self.connection[MONGO_DBNAME]
+        fake_contact = self.random_contacts(1)
+        fake_contact_id = _db.contacts.insert(fake_contact)[0]
+        fake_contact_url = self.known_resource_url + "/" + str(fake_contact_id)
+        _db.invoices.update({'_id': ObjectId(self.invoice_id)},
+                            {'$set': {'person': fake_contact_id}})
+
+        invoices = self.domain['invoices']
+        invoices['embedding'] = True
+        invoices['schema']['person']['data_relation']['embeddable'] = True
+        embedded = '{"person": 1}'
+
+        r = self.test_client.get(
+            self.invoice_id_url + '?embedded=%s' % embedded)
+        data, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertTrue('location' in data['person'])
+
+        # Get embedded doc etag so we can delete it
+        r = self.test_client.get(fake_contact_url)
+        embedded_contact_etag = r.headers['ETag']
+
+        # Delete embedded contact
+        data, status = self.delete(
+            fake_contact_url, headers=[('If-Match', embedded_contact_etag)])
+        self.assert204(status)
+
+        # embedded 'person' should now be empty
+        r = self.test_client.get(
+            self.invoice_id_url + '?embedded=%s' % embedded)
+        data, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertEqual(data['person'], None)
+
+    def test_softdeleted_get_response_skips_embedded_expansion(self):
+        """Soft deleted documents should not expand their embedded documents when
+        returned in a 410 Gone response. The deleted document data should
+        reflect the state of the document when it was deleted, not change if
+        still active embedded documents are updated
+        """
+        # Confirm embedded document works before delete
+        _db = self.connection[MONGO_DBNAME]
+        fake_contact = self.random_contacts(1)
+        fake_contact_id = _db.contacts.insert(fake_contact)[0]
+        _db.invoices.update({'_id': ObjectId(self.invoice_id)},
+                            {'$set': {'person': fake_contact_id}})
+
+        invoices = self.domain['invoices']
+        invoices['embedding'] = True
+        invoices['schema']['person']['data_relation']['embeddable'] = True
+        embedded = '{"person": 1}'
+
+        r = self.test_client.get(
+            self.invoice_id_url + '?embedded=%s' % embedded)
+        invoice_etag = r.headers['ETag']
+        data, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertTrue('location' in data['person'])
+
+        # Soft delete document
+        data, status = self.delete(
+            self.invoice_id_url, headers=[('If-Match', invoice_etag)])
+        self.assert204(status)
+
+        # Document in 410 should not expand person
+        r = self.test_client.get(
+            self.invoice_id_url + '?embedded=%s' % embedded)
+        data, status = self.parse_response(r)
+        self.assert410(status)
+        self.assertEqual(data['person'], str(fake_contact_id))
+
+    def test_softdelete_caching(self):
+        """410 Gone responses after soft delete should be cacheable
+        """
+        # Soft delete item
+        r, status = self.delete(self.item_id_url, headers=self.etag_headers)
+        self.assert204(status)
+
+        # delete should have invalidated any previously cached 200 responses
+        r = self.test_client.get(
+            self.item_id_url, headers=[('If-None-Match', self.item_etag)])
+        self.assert410(r.status_code)
+
+        post_delete_etag = r.headers['ETag']
+
+        # validate cached 410 response data
+        r = status = self.test_client.get(
+            self.item_id_url, headers=[('If-None-Match', post_delete_etag)])
+        self.assert304(r.status_code)
+
+    def test_softdelete_datalayer(self):
+        """Soft deleted items should not be returned by find methods in the Eve
+        data layer unless show_deleted is explicitly configured in the request,
+        the deleted field is included in the lookup, or the operation is 'raw'.
+        """
+        # Soft delete item
+        r, status = self.delete(self.item_id_url, headers=self.etag_headers)
+        self.assert204(status)
+
+        with self.app.test_request_context():
+            # find_one should only return item if a request w/ show_deleted ==
+            # True is passed or if the deleted field is part of the lookup
+            req = ParsedRequest()
+            doc = self.app.data.find_one(
+                self.known_resource, req, _id=self.item_id)
+            self.assertEqual(doc, None)
+
+            req.show_deleted = True
+            doc = self.app.data.find_one(
+                self.known_resource, req, _id=self.item_id)
+            self.assertNotEqual(doc, None)
+            self.assertEqual(doc.get(self.DELETED), True)
+
+            req.show_deleted = False
+            doc = self.app.data.find_one(
+                self.known_resource, req, _id=self.item_id, _deleted=True)
+            self.assertNotEqual(doc, None)
+            self.assertEqual(doc.get(self.DELETED), True)
+
+            # find_one_raw should always return a document, soft deleted or not
+            doc = self.app.data.find_one_raw(
+                self.known_resource, _id=ObjectId(self.item_id))
+            self.assertNotEqual(doc, None)
+            self.assertEqual(doc.get(self.DELETED), True)
+
+            # find should only return deleted items if a request with
+            # show_deleted == True is passed or if the deleted field is part of
+            # the lookup
+            req.show_deleted = False
+            docs = self.app.data.find(self.known_resource, req, None)
+            undeleted_count = docs.count()
+
+            req.show_deleted = True
+            docs = self.app.data.find(self.known_resource, req, None)
+            with_deleted_count = docs.count()
+            self.assertEqual(undeleted_count, with_deleted_count - 1)
+
+            req.show_deleted = False
+            docs = self.app.data.find(
+                self.known_resource, req, {self.DELETED: True})
+            deleted_count = docs.count()
+            self.assertEqual(deleted_count, 1)
+
+            # find_list_of_ids will return deleted documents if given their id
+            docs = self.app.data.find_list_of_ids(
+                self.known_resource, [ObjectId(self.item_id)])
+            self.assertEqual(docs.count(), 1)
 
 
 class TestDeleteEvents(TestBase):

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -574,7 +574,7 @@ class TestGet(TestBase):
                                             '?embedded=%s' % embedded))
         self.assert200(r.status_code)
         content = json.loads(r.get_data())
-        self.assertTrue(content['_items'][0]['person'], self.item_id)
+        self.assertEqual(content['_items'][0]['person'], str(fake_contact_id))
 
         # Set field to be embedded
         invoices['schema']['person']['data_relation']['embeddable'] = True
@@ -585,7 +585,7 @@ class TestGet(TestBase):
                                             '?embedded=%s' % embedded))
         self.assert200(r.status_code)
         content = json.loads(r.get_data())
-        self.assertTrue(content['_items'][0]['person'], self.item_id)
+        self.assertEqual(content['_items'][0]['person'], str(fake_contact_id))
 
         # Test that it works
         invoices['embedding'] = True

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -735,7 +735,7 @@ class TestCompleteVersioning(TestNormalVersioning):
 
     def test_softdelete(self):
         """ Deleting a versioned item with soft delete enabled should create a
-        new version marked as deleted, which is returned with `410 Gone` in
+        new version marked as deleted, which is returned with 404 Not Found in
         response to GET requests. GETs of previous versions should continue to
         respond with `200 OK` responses. Requests for `?version=all/diff`
         should include the soft deleted version as if it were a normal version
@@ -751,17 +751,17 @@ class TestCompleteVersioning(TestNormalVersioning):
         self.assertTrue(self.countDocuments(self.item_id) == 1)
         self.assertTrue(self.countShadowDocuments(self.item_id) == 2)
 
-        # GET primary should return `410 Gone` w/ doc + _deleted == True
+        # GET primary should return `404 Not Found` w/ doc + _deleted == True
         r = self.test_client.get(self.item_id_url)
         document, status = self.parse_response(r)
-        self.assert410(status)
+        self.assert404(status)
         self.assertEqual(document[self.latest_version_field], 2)
         self.assertEqual(document.get(self.deleted_field), True)
 
-        # GET v2 should return `410 Gone` w/ doc + _deleted == True
+        # GET v2 should return `404 Not Found` w/ doc + _deleted == True
         r = self.test_client.get(self.item_id_url + "?version=2")
         document, status = self.parse_response(r)
-        self.assert410(status)
+        self.assert404(status)
         self.assertEqual(document[self.latest_version_field], 2)
         self.assertEqual(document.get(self.deleted_field), True)
 

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -73,6 +73,7 @@ class TestVersioningBase(TestBase):
         domain = copy.copy(self.domain)
         for resource, settings in domain.items():
             # rebuild resource settings for soft delete
+            del settings['soft_delete']
             self.app.register_resource(resource, settings)
 
         self.deleted_field = self.app.config['DELETED']

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -528,14 +528,14 @@ class TestCompleteVersioning(TestNormalVersioning):
         self.assertEqualFields(self.item_change, items[1], self.fields)
         changed_fields = self.fields + [
             self.version_field,
-            self.app.config['LAST_UPDATED'],
             self.app.config['ETAG']]
-        self.assertTrue(field in items[1] for field in changed_fields)
-        # since the test routine happens so fast, `LAST_UPDATED` is probably
-        # not in the diff (the date output only has a one second resolution)
+        for field in changed_fields:
+            self.assertTrue(field in items[1], "%s not in diffs" % field)
+        # since the test routine happens so fast, `LAST_UPDATED` may or may not
+        # be in the diff (the date output only has a one second resolution)
         self.assertTrue(
             len(items[1].keys()) == len(changed_fields) or
-            len(items[1].keys()) == len(changed_fields) - 1)
+            len(items[1].keys()) == len(changed_fields) + 1)
         self.assertEqual(items[1][self.app.config['ETAG']], etag2)
 
         # TODO: could also verify that a 3rd iteration is a diff of the 2nd
@@ -795,8 +795,9 @@ class TestCompleteVersioning(TestNormalVersioning):
             self.app.config['ETAG']]
         self.assertTrue(
             len(items[1].keys()) == len(changed_fields) or
-            len(items[1].keys()) == len(changed_fields) - 1)
-        self.assertTrue(field in items[1] for field in changed_fields)
+            len(items[1].keys()) == len(changed_fields) + 1)
+        for field in changed_fields:
+            self.assertTrue(field in items[1], "%s not in diffs" % field)
 
 
 class TestVersionedDataRelation(TestNormalVersioning):

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -84,7 +84,7 @@ class ParsedRequest(object):
     embedded = None
 
     # `show_deleted` True when ?show_deleted is included in query.
-    # Only relevant when SOFT_DELETE is enabled. Defaults to False.
+    # Only relevant when soft delete is enabled. Defaults to False.
     show_deleted = False
 
     # `args` value of the original request. Defaults to None.
@@ -414,7 +414,7 @@ def auto_fields(resource):
         fields.append(config.LATEST_VERSION)  # on-the-fly meta data
         fields.append(config.ID_FIELD + config.VERSION_ID_SUFFIX)
 
-    if config.SOFT_DELETE is True:
+    if config.DOMAIN[resource]['soft_delete'] is True:
         fields.append(config.DELETED)
 
     return fields

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -83,7 +83,7 @@ class ParsedRequest(object):
     # `embedded` value of the query string (?embedded). Defaults to None.
     embedded = None
 
-    # `show_deleted` True when ?show_deleted is included in query.
+    # `show_deleted` True when the SHOW_DELETED_PARAM is included in query.
     # Only relevant when soft delete is enabled. Defaults to False.
     show_deleted = False
 
@@ -126,7 +126,7 @@ def parse_request(resource):
     if settings['embedding']:
         r.embedded = args.get(config.QUERY_EMBEDDED)
 
-    r.show_deleted = 'show_deleted' in args
+    r.show_deleted = config.SHOW_DELETED_PARAM in args
 
     max_results_default = config.PAGINATION_DEFAULT if \
         settings['pagination'] else 0

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -83,6 +83,10 @@ class ParsedRequest(object):
     # `embedded` value of the query string (?embedded). Defaults to None.
     embedded = None
 
+    # `show_deleted` True when ?show_deleted is included in query.
+    # Only relevant when SOFT_DELETE is enabled. Defaults to False.
+    show_deleted = False
+
     # `args` value of the original request. Defaults to None.
     args = None
 
@@ -121,6 +125,8 @@ def parse_request(resource):
         r.sort = args.get(config.QUERY_SORT)
     if settings['embedding']:
         r.embedded = args.get(config.QUERY_EMBEDDED)
+
+    r.show_deleted = 'show_deleted' in args
 
     max_results_default = config.PAGINATION_DEFAULT if \
         settings['pagination'] else 0
@@ -407,6 +413,9 @@ def auto_fields(resource):
         fields.append(config.VERSION)
         fields.append(config.LATEST_VERSION)  # on-the-fly meta data
         fields.append(config.ID_FIELD + config.VERSION_ID_SUFFIX)
+
+    if config.SOFT_DELETE is True:
+        fields.append(config.DELETED)
 
     return fields
 

--- a/eve/versioning.py
+++ b/eve/versioning.py
@@ -187,6 +187,8 @@ def diff_document(resource_def, old_doc, new_doc):
         app.config['DATE_CREATED'],
         app.config['ETAG'],
         app.config['LINKS']]
+    if app.config['SOFT_DELETE'] is True:
+        fields.append(app.config['DELETED'])
 
     for field in fields:
         if field in new_doc and \

--- a/eve/versioning.py
+++ b/eve/versioning.py
@@ -58,7 +58,7 @@ def resolve_document_version(document, resource, method, latest_doc=None):
             document[version] = 1
 
         if method == 'PUT' or method == 'PATCH' or \
-                (method == 'DELETE' and app.config['SOFT_DELETE'] is True):
+                (method == 'DELETE' and resource_def['soft_delete'] is True):
             if not latest_doc:
                 abort(500, description=debug_error_message(
                     'I need the latest document here!'
@@ -187,7 +187,7 @@ def diff_document(resource_def, old_doc, new_doc):
         app.config['DATE_CREATED'],
         app.config['ETAG'],
         app.config['LINKS']]
-    if app.config['SOFT_DELETE'] is True:
+    if resource_def['soft_delete'] is True:
         fields.append(app.config['DELETED'])
 
     for field in fields:
@@ -304,7 +304,7 @@ def get_data_version_relation_document(data_relation, reference, latest=False):
         # The relation value field is unversioned, and will not be present in
         # the versioned collection. Need to find id field for version query
         req = ParsedRequest()
-        if config.SOFT_DELETE:
+        if resource_def['soft_delete']:
             req.show_deleted = True
         latest_version = app.data.find_one(
             collection, req, **{value_field: reference[value_field]})
@@ -330,7 +330,7 @@ def get_data_version_relation_document(data_relation, reference, latest=False):
     # Fetch the latest version of this document to use in version synthesis
     query = {id_field: referenced_version[versioned_id_field()]}
     req = ParsedRequest()
-    if config.SOFT_DELETE:
+    if resource_def['soft_delete']:
         # Still return latest after soft delete. It is needed to synthesize
         # full document version.
         req.show_deleted = True


### PR DESCRIPTION
Implements soft delete with consideration for the outline developed in issue #335. PR is large, but documentation in features.rst is a good place to start reviewing.

There is one noteworthy change from the implementation discussed in #335 that I'd like feedback on. I originally implemented responding to GET requests for soft deleted documents with ``410 Gone`` as described in the issue. After some more consideration and a side conversation with @joshvillbrandt, however, I moved to ``404 Not Found`` responses which include the document body. Returning the document in any 4xx response is odd, but the benefit of using 404s is that clients do not need any knowledge of soft delete to use the API correctly, whereas they would have to specially handle 410s regardless of whether or not they care about soft delete. This is especially beneficial for introducing soft delete to existing APIs.

Also of note - during testing of soft delete's behavior with embedded documents, I discovered that embedded versioned documents did not function as expected. They are fixed in commit [b928907](https://github.com/nicolaiarocci/eve/commit/b928907a87f940808e2f2e5ada32016ab2b5025a)
 