### PR TITLE
Remove dependency on the Flask request in Mongo datalayer

### DIFF
--- a/eve/io/media.py
+++ b/eve/io/media.py
@@ -27,14 +27,14 @@ class MediaStorage(object):
         """
         self.app = app
 
-    def get(self, id_or_filename):
+    def get(self, id_or_filename, resource=None):
         """ Opens the file given by name or unique id. Note that although the
         returned file is guaranteed to be a File object, it might actually be
         some subclass. Returns None if no file was found.
         """
         raise NotImplementedError
 
-    def put(self, content, filename=None, content_type=None):
+    def put(self, content, filename=None, content_type=None, resource=None):
         """ Saves a new file using the storage system, preferably with the name
         specified. If there already exists a file with this name name, the
         storage system may modify the filename as necessary to get a unique
@@ -47,14 +47,14 @@ class MediaStorage(object):
         """
         raise NotImplementedError
 
-    def delete(self, id_or_filename):
+    def delete(self, id_or_filename, resource=None):
         """ Deletes the file referenced by name or unique id. If deletion is
         not supported on the target storage system this will raise
         NotImplementedError instead
         """
         raise NotImplementedError
 
-    def exists(self, id_or_filename):
+    def exists(self, id_or_filename, resource=None):
         """ Returns True if a file referenced by the given name or unique id
         already exists in the storage system, or False if the name is available
         for a new file.

--- a/eve/io/mongo/media.py
+++ b/eve/io/mongo/media.py
@@ -46,7 +46,7 @@ class GridFSMediaStorage(MediaStorage):
         if not isinstance(self.app, Flask):
             raise TypeError('Application object must be a Eve application')
 
-    def fs(self):
+    def fs(self, resource=None):
         """ Provides the instance-level GridFS instance, instantiating it if
         needed.
 
@@ -58,12 +58,12 @@ class GridFSMediaStorage(MediaStorage):
             raise TypeError("Application data object must be of eve.io.Mongo "
                             "type.")
 
-        px = driver.current_mongo_prefix()
+        px = driver.current_mongo_prefix(resource)
         if px not in self._fs:
             self._fs[px] = GridFS(driver.pymongo(prefix=px).db)
         return self._fs[px]
 
-    def get(self, _id):
+    def get(self, _id, resource=None):
         """ Returns the file given by unique id. Returns None if no file was
         found.
 
@@ -80,27 +80,27 @@ class GridFSMediaStorage(MediaStorage):
 
         _file = None
         try:
-            _file = self.fs().get(_id)
+            _file = self.fs(resource).get(_id)
         except:
             pass
         return _file
 
-    def put(self, content, filename=None, content_type=None):
+    def put(self, content, filename=None, content_type=None, resource=None):
         """ Saves a new file in GridFS. Returns the unique id of the stored
         file. Also stores content type of the file.
         """
-        return self.fs().put(content, filename=filename,
-                             content_type=content_type)
+        return self.fs(resource).put(content, filename=filename,
+                                     content_type=content_type)
 
-    def delete(self, _id):
+    def delete(self, _id, resource=None):
         """ Deletes the file referenced by unique id.
         """
-        self.fs().delete(_id)
+        self.fs(resource).delete(_id)
 
-    def exists(self, id_or_document):
+    def exists(self, id_or_document, resource=None):
         """ Returns True if a file referenced by the unique id or the query
         document already exists, False otherwise.
 
         Valid query: {'filename': 'file.txt'}
         """
-        return self.fs().exists(id_or_document)
+        return self.fs(resource).exists(id_or_document)

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -290,7 +290,8 @@ class Mongo(DataLayer):
             filter_ = self.combine_queries(
                 filter_, {config.DELETED: {"$ne": True}})
 
-        document = self.pymongo(resource).db[datasource].find_one(filter_, projection)
+        document = self.pymongo(resource).db[datasource] \
+                                         .find_one(filter_, projection)
         return document
 
     def find_one_raw(self, resource, _id):
@@ -511,7 +512,8 @@ class Mongo(DataLayer):
         lookup = self._mongotize(lookup, resource)
         datasource, filter_, _, _ = self._datasource_ex(resource, lookup)
         try:
-            self.pymongo(resource).db[datasource].remove(filter_, **self._wc(resource))
+            self.pymongo(resource).db[datasource] \
+                                  .remove(filter_, **self._wc(resource))
         except pymongo.errors.OperationFailure as e:
             # see comment in :func:`insert()`.
             abort(500, description=debug_error_message(

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -690,7 +690,7 @@ def resolve_media_files(document, resource):
     """
     for field in resource_media_fields(document, resource):
         file_id = document[field]
-        _file = app.media.get(file_id)
+        _file = app.media.get(file_id, resource)
 
         if _file:
             # otherwise we have a valid file and should send extended response
@@ -778,14 +778,14 @@ def store_media_files(document, resource, original=None):
         if original and field in original:
             # since file replacement is not supported by the media storage
             # system, we first need to delete the file being replaced.
-            app.media.delete(original[field])
+            app.media.delete(original[field], resource)
 
         if document[field]:
             # store file and update document with file's unique id/filename
             # also pass in mimetype for use when retrieving the file
             document[field] = app.media.put(
                 document[field], filename=document[field].filename,
-                content_type=document[field].mimetype)
+                content_type=document[field].mimetype, resource=resource)
 
 
 def resource_media_fields(document, resource):

--- a/eve/methods/delete.py
+++ b/eve/methods/delete.py
@@ -140,7 +140,7 @@ def deleteitem_internal(
 
         for field in media_fields:
             if field in original:
-                app.media.delete(original[field])
+                app.media.delete(original[field], resource)
 
         id = original[config.ID_FIELD]
         app.data.remove(resource, {config.ID_FIELD: id})

--- a/eve/tests/io/media.py
+++ b/eve/tests/io/media.py
@@ -26,6 +26,7 @@ class TestGridFSMediaStorage(TestBase):
     def setUp(self):
         super(TestGridFSMediaStorage, self).setUp()
         self.url = self.known_resource_url
+        self.resource = self.known_resource
         self.headers = [('Content-Type', 'multipart/form-data')]
         self.test_field, self.test_value = 'ref', "1234567890123456789054321"
         # we want an explicit binary as Py3 encodestring() expects binaries.
@@ -188,7 +189,7 @@ class TestGridFSMediaStorage(TestBase):
 
         with self.app.test_request_context():
             # previous media doesn't exist anymore (it's been deleted)
-            self.assertFalse(self.app.media.exists(media_id))
+            self.assertFalse(self.app.media.exists(media_id, self.resource))
 
     def test_gridfs_media_storage_patch(self):
         r, s = self._post()
@@ -222,7 +223,7 @@ class TestGridFSMediaStorage(TestBase):
 
         with self.app.test_request_context():
             # previous media doesn't exist anymore (it's been deleted)
-            self.assertFalse(self.app.media.exists(media_id))
+            self.assertFalse(self.app.media.exists(media_id, self.resource))
 
     def test_gridfs_media_storage_patch_null(self):
         # set 'media' field to 'nullable'
@@ -266,7 +267,7 @@ class TestGridFSMediaStorage(TestBase):
 
         with self.app.test_request_context():
             # media doesn't exist anymore (it's been deleted)
-            self.assertFalse(self.app.media.exists(media_id))
+            self.assertFalse(self.app.media.exists(media_id, self.resource))
 
         # GET returns 404
         r, s = self.parse_response(self.test_client.get('%s/%s' % (self.url,
@@ -302,7 +303,7 @@ class TestGridFSMediaStorage(TestBase):
 
         with self.app.test_request_context():
             # media doesn't exist anymore (it's been deleted)
-            self.assertFalse(self.app.media.exists(media_id))
+            self.assertFalse(self.app.media.exists(media_id, self.resource))
 
         # GET returns 404
         r, s = self.parse_response(self.test_client.get('%s/%s' % (self.url,
@@ -361,7 +362,7 @@ class TestGridFSMediaStorage(TestBase):
         media_id = _db.contacts.find_one({ID_FIELD: ObjectId(_id)})['media']
 
         # verify it's actually stored in the media storage system
-        self.assertTrue(self.app.media.exists(media_id))
+        self.assertTrue(self.app.media.exists(media_id, self.resource))
         return media_id
 
     def _post(self):


### PR DESCRIPTION
Fix for https://github.com/nicolaiarocci/eve/issues/632
The only existing dependency is on the app.config, this shouldn't be a problem in most of the cases.
For Celery, we just add the Eve app config to Celery app config.