### PR TITLE
Added 'MEDIA_CUSTOM_URL' setting for #639

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Patches and Contributions
 - Grisha K.
 - Hannes Tiede
 - Harro van der Klauw
+- Henrique Barroso
 - James Stewart
 - Jaroslav Semančík
 - Javier Gonel

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -174,7 +174,7 @@ RETURN_MEDIA_AS_BASE64_STRING = True
 RETURN_MEDIA_AS_URL = False
 MEDIA_ENDPOINT = 'media'
 MEDIA_URL = 'regex("[a-f0-9]{24}")'
-MEDIA_CUSTOM_URL = None
+MEDIA_BASE_URL = None
 
 # list of extra fields to be included with every POST response. This list
 # should not include the 'standard' fields (ID_FIELD, LAST_UPDATED,

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -174,6 +174,7 @@ RETURN_MEDIA_AS_BASE64_STRING = True
 RETURN_MEDIA_AS_URL = False
 MEDIA_ENDPOINT = 'media'
 MEDIA_URL = 'regex("[a-f0-9]{24}")'
+MEDIA_CUSTOM_URL = None
 
 # list of extra fields to be included with every POST response. This list
 # should not include the 'standard' fields (ID_FIELD, LAST_UPDATED,

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -698,7 +698,10 @@ def resolve_media_files(document, resource):
             if config.RETURN_MEDIA_AS_BASE64_STRING:
                 ret_file = base64.encodestring(_file.read())
             elif config.RETURN_MEDIA_AS_URL:
-                ret_file = '%s/%s/%s' % (app.api_prefix,
+                if config.MEDIA_CUSTOM_URL is not None:
+                    ret_file = '%s%s' % (config.MEDIA_CUSTOM_URL, file_id)
+                else:
+                    ret_file = '%s/%s/%s' % (app.api_prefix,
                                          config.MEDIA_ENDPOINT,
                                          file_id)
             else:

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -698,13 +698,10 @@ def resolve_media_files(document, resource):
             if config.RETURN_MEDIA_AS_BASE64_STRING:
                 ret_file = base64.encodestring(_file.read())
             elif config.RETURN_MEDIA_AS_URL:
-                if config.MEDIA_CUSTOM_URL is not None:
-                    ret_file = '%s%s' % (config.MEDIA_CUSTOM_URL,
+                prefix = config.MEDIA_BASE_URL if config.MEDIA_BASE_URL \
+                    is not None else app.api_prefix
+                ret_file = '%s/%s/%s' % (prefix, config.MEDIA_ENDPOINT,
                                          file_id)
-                else:
-                    ret_file = '%s/%s/%s' % (app.api_prefix,
-                                             config.MEDIA_ENDPOINT,
-                                             file_id)
             else:
                 ret_file = None
 

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -699,11 +699,12 @@ def resolve_media_files(document, resource):
                 ret_file = base64.encodestring(_file.read())
             elif config.RETURN_MEDIA_AS_URL:
                 if config.MEDIA_CUSTOM_URL is not None:
-                    ret_file = '%s%s' % (config.MEDIA_CUSTOM_URL, file_id)
+                    ret_file = '%s%s' % (config.MEDIA_CUSTOM_URL,
+                                         file_id)
                 else:
                     ret_file = '%s/%s/%s' % (app.api_prefix,
-                                         config.MEDIA_ENDPOINT,
-                                         file_id)
+                                             config.MEDIA_ENDPOINT,
+                                             file_id)
             else:
                 ret_file = None
 

--- a/eve/tests/io/media.py
+++ b/eve/tests/io/media.py
@@ -352,7 +352,8 @@ class TestGridFSMediaStorage(TestBase):
 
         with self.app.test_request_context():
             media_id = self.assertMediaStored(_id)
-        self.assertEqual('%s%s' % (self.app.config['MEDIA_CUSTOM_URL'], media_id), url)
+        self.assertEqual('%s%s' % (self.app.config['MEDIA_CUSTOM_URL'],
+                         media_id), url)
 
     def assertMediaField(self, _id, encoded, clean):
         # GET the file at the item endpoint

--- a/eve/tests/io/media.py
+++ b/eve/tests/io/media.py
@@ -333,11 +333,12 @@ class TestGridFSMediaStorage(TestBase):
         response = self.test_client.get(url)
         self.assertEqual(self.clean, response.get_data())
 
-    def test_gridfs_media_storage_custom_url(self):
+    def test_gridfs_media_storage_base_url(self):
         self.app._init_media_endpoint()
         self.app.config['RETURN_MEDIA_AS_BASE64_STRING'] = False
         self.app.config['RETURN_MEDIA_AS_URL'] = True
-        self.app.config['MEDIA_CUSTOM_URL'] = 'http://foo.bar/'
+        self.app.config['MEDIA_BASE_URL'] = 'http://s3-us-west-2.amazonaws.com'
+        self.app.config['MEDIA_ENDPOINT'] = 'foo'
 
         r, s = self._post()
         self.assertEqual(STATUS_OK, r[STATUS])
@@ -352,8 +353,8 @@ class TestGridFSMediaStorage(TestBase):
 
         with self.app.test_request_context():
             media_id = self.assertMediaStored(_id)
-        self.assertEqual('%s%s' % (self.app.config['MEDIA_CUSTOM_URL'],
-                         media_id), url)
+        self.assertEqual('%s/%s/%s' % (self.app.config['MEDIA_BASE_URL'],
+                         self.app.config['MEDIA_ENDPOINT'], media_id), url)
 
     def assertMediaField(self, _id, encoded, clean):
         # GET the file at the item endpoint

--- a/eve/tests/io/media.py
+++ b/eve/tests/io/media.py
@@ -333,6 +333,27 @@ class TestGridFSMediaStorage(TestBase):
         response = self.test_client.get(url)
         self.assertEqual(self.clean, response.get_data())
 
+    def test_gridfs_media_storage_custom_url(self):
+        self.app._init_media_endpoint()
+        self.app.config['RETURN_MEDIA_AS_BASE64_STRING'] = False
+        self.app.config['RETURN_MEDIA_AS_URL'] = True
+        self.app.config['MEDIA_CUSTOM_URL'] = 'http://foo.bar/'
+
+        r, s = self._post()
+        self.assertEqual(STATUS_OK, r[STATUS])
+        _id = r[ID_FIELD]
+
+        # GET the file at the resource endpoint
+        where = 'where={"%s": "%s"}' % (ID_FIELD, _id)
+        r, s = self.parse_response(
+            self.test_client.get('%s?%s' % (self.url, where)))
+        self.assertEqual(len(r['_items']), 1)
+        url = r['_items'][0]['media']
+
+        with self.app.test_request_context():
+            media_id = self.assertMediaStored(_id)
+        self.assertEqual('%s%s' % (self.app.config['MEDIA_CUSTOM_URL'], media_id), url)
+
     def assertMediaField(self, _id, encoded, clean):
         # GET the file at the item endpoint
         r, s = self.parse_response(self.test_client.get('%s/%s' % (self.url,


### PR DESCRIPTION
Allows media urls to use a custom URL as a base pattern.
When 'RETURN_MEDIA_AS_URL' is set to True and 'MEDIA_CUSTOM_URL' is not None, any media files
in a collection will return a concatenation of this setting plus the file ID.

This allows custom 'MediaStorage' to be much more flexible.