### PR TITLE
Added option to use a different authorization database.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,3 +102,4 @@ Patches and Contributions
 - xgdgsc
 - boosh
 - dccrazyboy
+- David Wood

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -477,6 +477,8 @@ uppercase.
 
 ``MONGO_DBNAME``                    MongoDB database name.
 
+``MONGO_AUTHDBNAME``                MongoDB authorization database name. Defaults to ``None``.
+
 ``MONGO_MAX_POOL_SIZE``             The maximum number of idle connections 
                                     maintained in the PyMongo connection pool.
                                     Default: PyMongo default.

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -872,6 +872,8 @@ def create_index(app, resource, name, list_of_keys, index_options):
         if key('USERNAME') in app.config else None
     password = app.config[key('PASSWORD')] \
         if key('PASSWORD') in app.config else None
+    auth_db_name = app.config[key('AUTHDBNAME')] \
+        if key('AUTHDBNAME') in app.config else None
     host = app.config[key('HOST')]
     port = app.config[key('PORT')]
     auth = (username, password)
@@ -880,7 +882,7 @@ def create_index(app, resource, name, list_of_keys, index_options):
     db = conn[db_name]
 
     if any(auth):
-        db.authenticate(username, password)
+        db.authenticate(username, password, source=auth_db_name)
 
     coll = db[collection]
 


### PR DESCRIPTION
Hi,

I added a new configuration value, `MONGO_AUTHDBNAME`, that is passed to [PyMongo's authenticate function](http://api.mongodb.org/python/current/examples/authentication.html#delegated-authentication) and should allow for authentication on databases different from the main database that's used for the data storage.

I've added it to the documentation, but unfortunately was unable to find where it should be included in the tests, however, all the tests that are existing, run fine with no issues. I'd appreciate some pointers to where tests should be included for this.