### PR TITLE
Improve performance of GET requests to versioned resources

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -10,7 +10,6 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-import copy
 import math
 from flask import current_app as app, abort, request
 from .common import ratelimit, epoch, pre_event, resolve_embedded_fields, \
@@ -226,7 +225,7 @@ def getitem(resource, **lookup):
 
     # synthesize old document version(s)
     if resource_def['versioning'] is True:
-        latest_doc = copy.deepcopy(document)
+        latest_doc = document
         document = get_old_document(
             resource, req, lookup, document, version)
 

--- a/eve/versioning.py
+++ b/eve/versioning.py
@@ -239,8 +239,8 @@ def synthesize_versioned_document(document, delta, resource_def):
 
 
 def get_old_document(resource, req, lookup, document, version):
-    """ Returns an old document if appropriate, otherwise passes the given
-    document through.
+    """ Returns an old document if appropriate, otherwise returns a copy of the
+    given document.
 
     :param resource: the name of the resource.
     :param req: the parsed request object.
@@ -269,12 +269,14 @@ def get_old_document(resource, req, lookup, document, version):
         delta = app.data.find_one(resource + config.VERSIONS, req, **lookup)
         if not delta:
             abort(404)
-        document = synthesize_versioned_document(
+        old_document = synthesize_versioned_document(
             document,
             delta,
             config.DOMAIN[resource])
+    else:
+        old_document = copy.deepcopy(document)
 
-    return document
+    return old_document
 
 
 def get_data_version_relation_document(data_relation, reference, latest=False):


### PR DESCRIPTION
Synthesizing a specific document version in GET requests uses two `deepcopy` calls, but only one is necessary if `get_old_document` does not edit the document passed to it. Improves performance for large documents.