### PR TITLE
Update serialize to gracefully handle non-dictionary values in dict type fields.

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -346,7 +346,12 @@ def serialize(document, resource=None, schema=None, fields=None):
                         embedded = [document[field]] if field_type == 'dict' \
                             else document[field]
                         for subdocument in embedded:
-                            if 'schema' in field_schema:
+                            if type(subdocument) is not dict:
+                                # value is not a dict - continue serialization
+                                # error will be reported by validation if
+                                # appropriate (could be allowed nullable dict)
+                                continue
+                            elif 'schema' in field_schema:
                                 serialize(subdocument,
                                           schema=field_schema['schema'])
                             else:

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -144,6 +144,30 @@ class TestSerializer(TestBase):
             for item in sublist:
                 self.assertTrue(isinstance(item['_id'], ObjectId))
 
+    def test_serialize_null_dictionary(self):
+        # Serialization should continue after encountering a null value dict
+        # field. Field may be nullable, or error will be caught in validation.
+        schema = {
+            'nullable_dict': {
+                'type': 'dict',
+                'nullable': True,
+                'schema': {
+                    'simple_field': {
+                        'type': 'number'
+                    }
+                }
+            }
+        }
+        doc = {
+            'nullable_dict': None
+        }
+        with self.app.app_context():
+            try:
+                serialize(doc, schema=schema)
+            except Exception:
+                self.assertTrue(False, "Serializing null dictionaries should "
+                                       "not raise an exception.")
+
 
 class TestOpLogBase(TestBase):
     def setUp(self):


### PR DESCRIPTION
Nullable fields of type `dict` are not currently possible, as `methods.common.serialize` breaks when attempting to recursively serialize a null value. The same is true of other non-dictionary value types, which should fail in validation, not raise an exception during serialization. This PR allows serialization to continue, nullable `dict` fields to work as expected, and type errors to be reported accurately from the validator.