### PR TITLE
Using constant VERSION instead of hard coded '_version'

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -251,7 +251,8 @@ def getitem(resource, **lookup):
         cache_validators[cache_valid] += 1
     if req.if_none_match:
         if (resource_def['versioning'] is False) or \
-           (document['_version'] == document['_latest_version']):
+           (document[app.config['VERSION']] ==
+                document[app.config['LATEST_VERSION']]):
             cache_valid = (etag == req.if_none_match)
             cache_validators[cache_valid] += 1
     # If all cache validators are true, return 304

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -922,7 +922,7 @@ class TestVersionedDataRelation(TestNormalVersioning):
             item=r[self.app.config['ID_FIELD']],
             query='?embedded={"person": 1}')
         self.assert200(status)
-        self.assertEqual(response['person'].get('_version'), 1)
+        self.assertEqual(response['person'].get(version_field), 1)
 
         # reference second version... this should work
         data = {"person": {value_field: self.item_id, version_field: 2}}
@@ -934,7 +934,7 @@ class TestVersionedDataRelation(TestNormalVersioning):
             item=r[self.app.config['ID_FIELD']],
             query='?embedded={"person": 1}')
         self.assert200(status)
-        self.assertEqual(response['person'].get('_version'), 2)
+        self.assertEqual(response['person'].get(version_field), 2)
 
     def test_embedded(self):
         """ Perform a quick check to make sure that Eve can embedded with a
@@ -1064,7 +1064,7 @@ class TestVersionedDataRelationCustomField(TestNormalVersioning):
             item=r[self.app.config['ID_FIELD']],
             query='?embedded={"person": 1}')
         self.assert200(status)
-        self.assertEqual(response['person'].get('_version'), 1)
+        self.assertEqual(response['person'].get(self.version_field), 1)
 
 
 class TestVersionedDataRelationUnversionedField(TestNormalVersioning):
@@ -1102,7 +1102,7 @@ class TestVersionedDataRelationUnversionedField(TestNormalVersioning):
             item=r[self.app.config['ID_FIELD']],
             query='?embedded={"person": 1}')
         self.assert200(status)
-        self.assertEqual(response['person'].get('_version'), 1)
+        self.assertEqual(response['person'].get(self.version_field), 1)
 
 
 class TestPartialVersioning(TestNormalVersioning):


### PR DESCRIPTION
GET fails if you change the _version to some other field name.