### PR TITLE
WWW-Authenticate header syntax fix

### DIFF
--- a/eve/auth.py
+++ b/eve/auth.py
@@ -121,7 +121,7 @@ class BasicAuth(object):
         """ Returns a standard a 401 response that enables basic auth.
         Override if you want to change the response and/or the realm.
         """
-        resp = Response(None, 401, {'WWW-Authenticate': 'Basic realm:"%s"' %
+        resp = Response(None, 401, {'WWW-Authenticate': 'Basic realm="%s"' %
                                     __package__})
         abort(401, description='Please provide proper credentials',
               response=resp)
@@ -218,7 +218,7 @@ class TokenAuth(BasicAuth):
         """ Returns a standard a 401 response that enables basic auth.
         Override if you want to change the response and/or the realm.
         """
-        resp = Response(None, 401, {'WWW-Authenticate': 'Basic realm:"%s"' %
+        resp = Response(None, 401, {'WWW-Authenticate': 'Basic realm="%s"' %
                                     __package__})
         abort(401, description='Please provide proper credentials',
               response=resp)

--- a/eve/tests/auth.py
+++ b/eve/tests/auth.py
@@ -223,7 +223,7 @@ class TestBasicAuth(TestBase):
     def test_rfc2617_response(self):
         r = self.test_client.get('/')
         self.assert401(r.status_code)
-        self.assertTrue(('WWW-Authenticate', 'Basic realm:"%s"' %
+        self.assertTrue(('WWW-Authenticate', 'Basic realm="%s"' %
                          eve.__package__) in r.headers.to_wsgi_list())
 
     def test_allowed_roles_does_not_change(self):


### PR DESCRIPTION
According to [rfc2617](http://tools.ietf.org/html/rfc2617#section-2) the separator should be (=) instead of (:).
This caused at least chrome not to prompt user for the credentials, and not to send the Authorization header even when credentials were in the url.