### PR TITLE
Add some tests to demonstrate how dependencies with values doesn't work with patch and put

### DIFF
--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -552,6 +552,33 @@ class TestPatch(TestBase):
                                headers=[('If-Match', etag)])
         self.assert200(status)
 
+    def test_patch_dependent_field_value_on_origin_document(self):
+        """ Test that when patching a field which is dependent on another and
+        this other field is not provided with the patch but is still present
+        on the target document, the patch will be accepted. See #363.
+        """
+        # this will fail as dependent field is missing even in the
+        # document we are trying to update.
+        changes = {'dependency_field3': 'value'}
+        r, status = self.patch(self.item_id_url, data=changes,
+                               headers=[('If-Match', self.item_etag)])
+        self.assert422(status)
+
+        # update the stored document by setting the dependency field to
+        # the required value.
+        changes = {'dependency_field1': 'value'}
+        r, status = self.patch(self.item_id_url, data=changes,
+                               headers=[('If-Match', self.item_etag)])
+        self.assert200(status)
+
+        # now the field2 update will be accepted as the dependency field is
+        # present in the stored document already.
+        etag = r['_etag']
+        changes = {'dependency_field2': 'value'}
+        r, status = self.patch(self.item_id_url, data=changes,
+                               headers=[('If-Match', etag)])
+        self.assert200(status)
+
     def assertPatchResponse(self, response, item_id):
         self.assertTrue(STATUS in response)
         self.assertTrue(STATUS_OK in response[STATUS])

--- a/eve/tests/methods/put.py
+++ b/eve/tests/methods/put.py
@@ -242,6 +242,20 @@ class TestPut(TestBase):
         db_value = self.compare_put_with_get(field, r)
         self.assertEqual(db_value, test_value)
 
+    def test_put_dependency_fields_with_wrong_value(self):
+        # Test that if a dependency is not met, the put is refused
+        del(self.domain['contacts']['schema']['ref']['required'])
+        r, status = self.put(self.item_id_url,
+                             data={'dependency_field3': 'value'},
+                             headers=[('If-Match', self.item_etag)])
+        self.assert422(status)
+        r, status = self.put(self.item_id_url,
+                             data={'dependency_field1': 'value',
+                                   'dependency_field3': 'value'},
+                             headers=[('If-Match', self.item_etag)])
+        print r
+        self.assert200(status)
+
     def test_put_internal(self):
         # test that put_internal is available and working properly.
         test_field = 'ref'

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -95,6 +95,10 @@ contacts = {
             'type': 'string',
             'dependencies': ['dependency_field1']
         },
+        'dependency_field3': {
+            'type': 'string',
+            'dependencies': {'dependency_field1': 'value'}
+        },
         'read_only_field': {
             'type': 'string',
             'default': 'default',


### PR DESCRIPTION
I'm trying to use new Cerberus' `dependencies` with value deps, and I can't make it to fail when the dependency is not met.

I've pushed some failing test to demonstrate my issue. Did I miss something?