### PR TITLE
embedded documents following depth level

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -678,7 +678,8 @@ def resolve_embedded_documents(document, resource, embedded_fields):
 
     .. versionadded:: 0.1.0
     """
-    for field in embedded_fields:
+    # NOTE(Gonéri): We resolve the embedded documents at the end.
+    for field in sorted(embedded_fields, key=lambda a: a.count('.')):
         data_relation = field_definition(resource, field)['data_relation']
         getter = lambda ref: embedded_document(ref, data_relation, field)  # noqa
         fields_chain = field.split('.')


### PR DESCRIPTION
embedded_fields may point on a field that come from another embedded
document. For example, ['a.b.c', 'a.b', 'a']

The strategy is to sort out the different embedded_fields depending on
their number of '.'. This way, the ones with the greatest depth level
come last.

Combined with https://github.com/RedTurtle/eve-sqlalchemy/pull/47 it's
now possible to do include multi-level embedded resource with Eve-SQLAlchemy.