### PR TITLE
Fix filter validation

### DIFF
--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -235,6 +235,15 @@ class TestUtils(TestBase):
             self.assertTrue('key' in validate_filters(
                 {'$or': [{'key': 'val1'}, {'key': 'val2'}]},
                 self.known_resource))
+            self.assertTrue('$or' in validate_filters(
+                {'$or': 'val'},
+                self.known_resource))
+            self.assertTrue('$or' in validate_filters(
+                {'$or': {'key': 'val1'}},
+                self.known_resource))
+            self.assertTrue('$or' in validate_filters(
+                {'$or': ['val']},
+                self.known_resource))
 
         self.app.config['DOMAIN'][self.known_resource]['allowed_filters'] = \
             ['key']

--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from eve.tests import TestBase
 from eve.utils import parse_request, str_to_date, config, weak_date, \
     date_to_str, querydef, document_etag, extract_key_values, \
-    debug_error_message
+    debug_error_message, validate_filters
 
 
 class TestUtils(TestBase):
@@ -219,6 +219,38 @@ class TestUtils(TestBase):
             self.app.config['DEBUG'] = True
             self.assertEqual(debug_error_message('An error message'),
                              'An error message')
+
+    def test_validate_filters(self):
+        self.app.config['DOMAIN'][self.known_resource]['allowed_filters'] = []
+        with self.app.test_request_context():
+            self.assertTrue('key' in validate_filters(
+                {'key': 'val'},
+                self.known_resource))
+            self.assertTrue('key' in validate_filters(
+                {'key': ['val1', 'val2']},
+                self.known_resource))
+            self.assertTrue('key' in validate_filters(
+                {'key': {'$in': ['val1', 'val2']}},
+                self.known_resource))
+            self.assertTrue('key' in validate_filters(
+                {'$or': [{'key': 'val1'}, {'key': 'val2'}]},
+                self.known_resource))
+
+        self.app.config['DOMAIN'][self.known_resource]['allowed_filters'] = \
+            ['key']
+        with self.app.test_request_context():
+            self.assertTrue(validate_filters(
+                {'key': 'val'},
+                self.known_resource) is None)
+            self.assertTrue(validate_filters(
+                {'key': ['val1', 'val2']},
+                self.known_resource) is None)
+            self.assertTrue(validate_filters(
+                {'key': {'$in': ['val1', 'val2']}},
+                self.known_resource) is None)
+            self.assertTrue(validate_filters(
+                {'$or': [{'key': 'val1'}, {'key': 'val2'}]},
+                self.known_resource) is None)
 
 
 class DummyEvent(object):

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -377,7 +377,12 @@ def validate_filters(where, resource):
                 return "filter on '%s' not allowed" % key
 
             if key in ('$or', '$and', '$nor'):
+                if not isinstance(value, list):
+                    return "operator '%s' expects a list of sub-queries" % key
                 for v in value:
+                    if not isinstance(v, dict):
+                        return "operator '%s' expects a list of sub-queries" \
+                            % key
                     r = validate_filter(v)
                     if r:
                         return r

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -379,7 +379,7 @@ def validate_filters(where, resource):
                     return "filter on '%s' not allowed" % key
                 if isinstance(value, dict):
                     r = validate_filter([value])
-                elif isinstance(value, list):
+                elif isinstance(value, list) and key in ('$or', '$and', '$nor'):
                     r = validate_filter(value)
 
                 if r:

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -371,25 +371,22 @@ def validate_filters(where, resource):
     operators = getattr(app.data, 'operators', set())
     allowed = config.DOMAIN[resource]['allowed_filters'] + list(operators)
 
-    def validate_filter(filters):
-        r = None
-        for d in filters:
-            for key, value in d.items():
-                if key not in allowed:
-                    return "filter on '%s' not allowed" % key
-                if isinstance(value, dict):
-                    r = validate_filter([value])
-                elif isinstance(value, list) and key in ('$or', '$and', '$nor'):
-                    r = validate_filter(value)
+    def validate_filter(filter):
+        for key, value in filter.items():
+            if key not in allowed:
+                return "filter on '%s' not allowed" % key
 
+            if key in ('$or', '$and', '$nor'):
+                for v in value:
+                    r = validate_filter(v)
+                    if r:
+                        return r
+            elif isinstance(value, dict):
+                r = validate_filter(value)
                 if r:
-                    break
-            if r:
-                break
+                    return r
 
-        return r
-
-    return validate_filter([where]) if '*' not in allowed else None
+    return validate_filter(where) if '*' not in allowed else None
 
 
 def auto_fields(resource):


### PR DESCRIPTION
Currently, `eve.utils.validate_filters` fails to validate the following query selectors:
- `{"key": {"$in": ["val1", "val2"]}`
- `{"key": ["val1", "val2"]}`
- `{"key": {"$mod": [2, 1]}}`

More precisely, it fails to validate query selectors that contain a value of the list data-type which is not a list of sub-queries.

This PR attempts to address this issue (29b0aee). I took this opportunity to refactor `validate_filter` (4eb445a) and add more feedback if the validation fails (6438062).