### PR TITLE
Fix versioning of resources which define a custom ID_FIELD

### DIFF
--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -1321,3 +1321,18 @@ class TestLateVersioning(TestVersioningBase):
             item=invoice_id, query='?embedded={"person": 1}')
         self.assert200(status)
         self.assertTrue('ref' in response['person'])
+
+
+class TestVersioningWithCustomIdField(TestNormalVersioning):
+    def setUp(self):
+        super(TestVersioningWithCustomIdField, self).setUp()
+        self.domain['contacts']['schema'][self.app.config['ID_FIELD']] = {
+            'type': 'string',
+        }
+        self.enableVersioning()
+        self.insertTestData()
+
+    def test_getitem(self):
+        """ Make sure we can insert at least two versioning documents.
+        """
+        self.do_test_getitem(partial=False)

--- a/eve/versioning.py
+++ b/eve/versioning.py
@@ -155,16 +155,18 @@ def versioned_fields(resource_def):
 
     .. versionadded:: 0.4
     """
+    if resource_def['versioning'] is not True:
+        return []
+
     schema = resource_def['schema']
-    fields = []
-    if resource_def['versioning'] is True:
-        fields.append(app.config['LAST_UPDATED'])
-        fields.append(app.config['ETAG'])
-        fields.append(app.config['DELETED'])
-        for field in schema:
-            if field not in schema or \
-                    schema[field].get('versioned', True) is True:
-                fields.append(field)
+
+    fields = [f for f in schema
+              if schema[f].get('versioned', True) is True]
+
+    fields.extend((app.config['LAST_UPDATED'],
+                   app.config['ETAG'],
+                   app.config['DELETED'],
+                   ))
 
     return fields
 

--- a/eve/versioning.py
+++ b/eve/versioning.py
@@ -161,7 +161,8 @@ def versioned_fields(resource_def):
     schema = resource_def['schema']
 
     fields = [f for f in schema
-              if schema[f].get('versioned', True) is True]
+              if schema[f].get('versioned', True) is True
+              and f != app.config['ID_FIELD']]
 
     fields.extend((app.config['LAST_UPDATED'],
                    app.config['ETAG'],


### PR DESCRIPTION
When versioning is enabled on a resource with a custom `ID_FIELD`, versioning documents will inherit their ID from the versioned document, making any update of the document result in a `DuplicateKeyError`.

This PR adresses this issue by excluding the `ID_FIELD` from the list of fields returned by `eve.versioning.versioned_fields`.