### PR TITLE
Responds with a valid response when HATEOAS is off

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -406,6 +406,14 @@ uppercase.
 
 ``META``                            Allows to customize the meta field. Defaults
                                     to ``_meta``
+                                    to ``_meta``.
+
+``INFO``                            String value to include an info section, with the
+                                    given INFO name, at the Eve homepage (suggested
+                                    value ``_info``). The info section will include
+                                    Eve server version and API version (API_VERSION,
+                                    if set).  ``None`` otherwise, if you do not want
+                                    to expose any server info. Defaults to ``None``.
 
 ``LINKS``                           Allows to customize the links field. Defaults
                                     to ``_links``.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -391,12 +391,6 @@ want to turn HATEOAS off? Well, if you know that your client application is not
 going to use the feature, then you might want to save on both bandwidth and
 performance. 
 
-.. admonition:: Please note
-
-    When HATEOAS is disabled, the API entry point (the home page) will return
-    a ``404``, since its only usefulness would be to return a list of available
-    resources, which is the standard behavior when HATEOAS is enabled.
-
 .. _jsonxml:
 
 JSON and XML Rendering

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -57,6 +57,11 @@ payload:
 ::
 
     {
+        "_info": {
+            "server": "Eve",
+            "version": "a.b.c",
+            "api_version": "x.y.z"
+        },
         "_links": {
             "child": [
                 {
@@ -66,6 +71,11 @@ payload:
             ]
         }
     }
+
+The `_info` section displays the current version of Eve (a.b.c) and the current
+version of the API as defined in your :ref:`global` configuration section. This
+is an optional feature that you can turn on by setting a value in the `INFO` value
+in your settings (defaults to off).
 
 API entry points adhere to the :ref:`hateoas_feature` principle and provide
 information about the resources accessible through the API. In our case

--- a/eve/__init__.py
+++ b/eve/__init__.py
@@ -71,6 +71,7 @@ LINKS = '_links'
 ETAG = '_etag'
 VERSION = '_version'
 META = '_meta'
+INFO = None
 
 QUERY_WHERE = 'where'
 QUERY_SORT = 'sort'

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -106,6 +106,7 @@ ETAG = '_etag'
 VERSION = '_version'            # field that stores the version number
 DELETED = '_deleted'            # field to store soft delete status
 META = '_meta'
+INFO = None
 VALIDATION_ERROR_STATUS = 422
 
 # return a single field validation error as a list (by default a single error

--- a/eve/endpoints.py
+++ b/eve/endpoints.py
@@ -18,8 +18,8 @@ from eve.auth import requires_auth
 from eve.methods import get, getitem, post, patch, delete, deleteitem, put
 from eve.methods.common import ratelimit
 from eve.render import send_response
-from eve.utils import config, request_method, debug_error_message, weak_date, \
-    date_to_rfc1123
+from eve.utils import config, request_method, weak_date, date_to_rfc1123
+import eve
 
 
 def collections_endpoint(**lookup):
@@ -121,8 +121,15 @@ def home_endpoint():
     .. versionchanged:: 0.1.0
        Support for optional HATEOAS.
     """
+    response = {}
+    if config.INFO:
+        info = {}
+        info['server'] = 'Eve'
+        info['version'] = eve.__version__
+        info['api_version'] = config.API_VERSION
+        response[config.INFO] = info
+
     if config.HATEOAS:
-        response = {}
         links = []
         for resource in config.DOMAIN.keys():
             internal = config.DOMAIN[resource]['internal_resource']
@@ -135,8 +142,7 @@ def home_endpoint():
         response[config.LINKS] = {'child': links}
         return send_response(None, (response,))
     else:
-        abort(404, debug_error_message("HATEOAS is disabled so we have no data"
-                                       " to display at the API homepage."))
+        return send_response(None, (response,))
 
 
 def error_endpoint(error):

--- a/eve/tests/response.py
+++ b/eve/tests/response.py
@@ -2,7 +2,9 @@
 
 from ast import literal_eval
 from eve.tests import TestBase
+from eve.utils import config
 import simplejson as json
+import eve
 
 
 class TestResponse(TestBase):
@@ -56,7 +58,18 @@ class TestNoHateoas(TestBase):
 
     def test_get_no_hateoas_homepage(self):
         r = self.test_client.get('/')
-        self.assert404(r.status_code)
+        self.assert200(r.status_code)
+
+    def test_get_no_hateoas_homepage_reply(self):
+        r = self.test_client.get('/')
+        resp = json.loads(r.get_data().decode())
+        if config.INFO:
+            self.assertEqual(resp[config.INFO]['server'], 'Eve')
+            self.assertEqual(resp[config.INFO]['version'], eve.__version__)
+            self.assertEqual(resp[config.INFO]['api_version'],
+                             config.API_VERSION)
+        else:
+            self.assertEqual(resp, {})
 
     def test_post_no_hateoas(self):
         data = {'item1': json.dumps({"ref": "1234567890123456789054321"})}


### PR DESCRIPTION
When HATEOAS is turned off, the server now responds with
an json response, stating the EVE and API versions, instead
of replying with a 404 error page.

Putting my money where my mouth is, regarding #685