### PR TITLE
Fix resource discovery in Mongo layer

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -804,12 +804,13 @@ class Mongo(DataLayer):
         # for other database implementations.
 
         auth = None
-        if resource is None and request and request.endpoint:
-            try:
+        try:
+            if resource is None and request and request.endpoint:
                 resource = request.endpoint[:request.endpoint.index('|')]
+            if request and request.endpoint:
                 auth = resource_auth(resource)
-            except ValueError:
-                pass
+        except ValueError:
+            pass
 
         px = auth.get_mongo_prefix() if auth else None
         if px is None:

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -803,11 +803,10 @@ class Mongo(DataLayer):
         # eve.io.media.MediaStorage interface, possibly breaking compatibility
         # for other database implementations.
 
-        resource, auth = None, None
-        if request.endpoint:
+        auth = None
+        if resource is None and request and request.endpoint:
             try:
-                if resource is None:
-                    resource = request.endpoint[:request.endpoint.index('|')]
+                resource = request.endpoint[:request.endpoint.index('|')]
                 auth = resource_auth(resource)
             except ValueError:
                 pass


### PR DESCRIPTION
Mongo layer should not depend on request context if possible, resource can be passed as a parameter.