### PR TITLE
Apply Cerberus' type coercion to documents

### DIFF
--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -159,6 +159,9 @@ def patch_internal(resource, payload=None, concurrency_check=False,
             validation = validator.validate_update(updates, object_id,
                                                    original)
         if validation:
+            # Apply coerced values
+            updates = validator.document
+
             # sneak in a shadow copy if it wasn't already there
             late_versioning_catch(original, resource)
 

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -181,6 +181,9 @@ def post_internal(resource, payl=None, skip_validation=False):
             else:
                 validation = validator.validate(document)
             if validation:  # validation is successful
+                # Apply coerced values
+                document = validator.document
+
                 # Populate meta and default fields
                 document[config.LAST_UPDATED] = \
                     document[config.DATE_CREATED] = date_utc

--- a/eve/methods/put.py
+++ b/eve/methods/put.py
@@ -150,6 +150,9 @@ def put_internal(resource, payload=None, concurrency_check=False,
             validation = validator.validate_replace(document, object_id,
                                                     original)
         if validation:
+            # Apply coerced values
+            document = validator.document
+
             # sneak in a shadow copy if it wasn't already there
             late_versioning_catch(original, resource)
 

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -598,6 +598,16 @@ class TestPatch(TestBase):
                                headers=headers)
         self.assert200(status)
 
+    def test_patch_type_coercion(self):
+        schema = self.domain[self.known_resource]['schema']
+        schema['aninteger']['coerce'] = lambda string: int(float(string))
+        changes = {'ref': '1234567890123456789054321', 'aninteger': '42.3'}
+        r, status = self.patch(self.item_id_url, data=changes,
+                               headers=[('If-Match', self.item_etag)])
+        self.assert200(status)
+        r, status = self.get(r['_links']['self']['href'])
+        self.assertEqual(r['aninteger'], 42)
+
     def assertPatchResponse(self, response, item_id, resource=None):
         id_field = self.domain[resource or self.known_resource]['id_field']
         self.assertTrue(STATUS in response)

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -648,6 +648,12 @@ class TestPost(TestBase):
         self.assertPostResponse(r)
         self.assertEqual(r['_id'], id)
 
+    def test_post_type_coercion(self):
+        schema = self.domain[self.known_resource]['schema']
+        schema['aninteger']['coerce'] = lambda string: int(float(string))
+        data = {'ref': '1234567890123456789054321', 'aninteger': '42.3'}
+        self.assertPostItem(data, 'aninteger', 42)
+
     def perform_post(self, data, valid_items=[0]):
         r, status = self.post(self.known_resource_url, data=data)
         self.assert201(status)

--- a/eve/tests/methods/put.py
+++ b/eve/tests/methods/put.py
@@ -317,6 +317,16 @@ class TestPut(TestBase):
         self.assert400(status)
         self.assertTrue('immutable' in r['_error']['message'])
 
+    def test_put_type_coercion(self):
+        schema = self.domain[self.known_resource]['schema']
+        schema['aninteger']['coerce'] = lambda string: int(float(string))
+        changes = {'ref': '1234567890123456789054321', 'aninteger': '42.3'}
+        r, status = self.put(self.item_id_url, data=changes,
+                             headers=[('If-Match', self.item_etag)])
+        self.assert200(status)
+        r, status = self.get(r['_links']['self']['href'])
+        self.assertEqual(r['aninteger'], 42)
+
     def perform_put(self, changes):
         r, status = self.put(self.item_id_url,
                              data=changes,


### PR DESCRIPTION
As far as I understood type coercion correctly, a successfully validated document should show the coerced values instead of the original ones. This commit changes Eve's behaviour regarding type coercion so coerced values get applied before the document is inserted or updated.