### PR TITLE
Add 'SCHEMA_ENDPOINT' option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -183,6 +183,8 @@ Version 0.6
 - Fix: Geopoint coordinates do not accept integers. Closes #591 (Joakim
   Uddholm.)
 - Fix: OpLog enabled makes PUT return wrong Etag. Closes #590.
+- New: ``SCHEMA_ENDPOINT`` allows resource schema to be returned from an API
+  endpoint
 
 Stable
 ------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -588,6 +588,9 @@ uppercase.
                                     and document changes are also logged to the
                                     :ref:`oplog`. Defaults to ``True``.
 
+``SCHEMA_ENDPOINT``                 Name of the :ref:`schema_endpoint`. Defaults
+                                    to ``None``.
+
 ``HEADER_TOTAL_COUNT``              Custom header containing total count of 
                                     items in response payloads for collection
                                     ``GET`` requests. This is handy for ``HEAD``

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1875,6 +1875,19 @@ query the oplog for changes occured on that endpoint.
     in case you are wondering yes, the Eve oplog is blatantly inpsired by the
     awesome `Replica Set Oplog`_.
 
+.. _schema_endpoint:
+
+The Schema Endpoint
+-------------------
+Resource schema can be exposed to API clients by enabling Eve's schema
+endpoint. To do so, set the ``SCHEMA_ENDPOINT`` configuration option to the API
+endpoint name from which you want to serve schema data. Once enabled, Eve will
+treat the endpoint as a read only resource containing JSON encoded Cerberus
+schema definitons, indexed by resource name. Resource visibility and
+authorization settings are honored, so internal resources or resources for
+which a request does not have read authentication will not be accessible at the
+schema endpoint. By default, ``SCHEMA_ENDPOINT`` is set to ``None``.
+
 MongoDB and SQL Support
 ------------------------
 Support for single or multiple MongoDB database/servers comes out of the box.

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -22,6 +22,7 @@
        'SOFT_DELETE' added and set to False.
        'DELETED' added and set to '_deleted'.
        'SHOW_DELETED_PARAM' added and set to 'show_deleted'.
+       'SCHEMA_ENDPOINT' added and set to None
 
     .. versionchanged:: 0.5
        'SERVER_NAME' removed.
@@ -185,6 +186,8 @@ RETURN_MEDIA_AS_URL = False
 MEDIA_ENDPOINT = 'media'
 MEDIA_URL = 'regex("[a-f0-9]{24}")'
 MEDIA_BASE_URL = None
+
+SCHEMA_ENDPOINT = None
 
 # list of extra fields to be included with every POST response. This list
 # should not include the 'standard' fields (ID_FIELD, LAST_UPDATED,

--- a/eve/endpoints.py
+++ b/eve/endpoints.py
@@ -14,7 +14,7 @@
 from bson import tz_util
 from flask import abort, request, current_app as app, Response
 
-from eve.auth import requires_auth
+from eve.auth import requires_auth, resource_auth
 from eve.methods import get, getitem, post, patch, delete, deleteitem, put
 from eve.methods.common import ratelimit
 from eve.render import send_response
@@ -131,6 +131,9 @@ def home_endpoint():
                     links.append({'href': '%s' % config.URLS[resource],
                                   'title': '%s' %
                                   config.DOMAIN[resource]['resource_title']})
+        if config.SCHEMA_ENDPOINT is not None:
+            links.append({'href': '%s' % config.SCHEMA_ENDPOINT,
+                          'title': '%s' % config.SCHEMA_ENDPOINT})
 
         response[config.LINKS] = {'child': links}
         return send_response(None, (response,))
@@ -186,3 +189,43 @@ def media_endpoint(_id):
                         direct_passthrough=True)
 
     return response
+
+
+@requires_auth('resource')
+def schema_item_endpoint(resource):
+    """ This endpoint is active when SCHEMA_ENDPOINT != None. It returns the
+    requested resource's schema definition in JSON format.
+    """
+    resource_config = app.config['DOMAIN'].get(resource)
+    if not resource_config or resource_config.get('internal_resource') is True:
+        return abort(404)
+
+    return send_response(None, (resource_config['schema'],))
+
+
+@requires_auth('home')
+def schema_collection_endpoint():
+    """ This endpoint is active when SCHEMA_ENDPOINT != None. It returns the
+    schema definition for all public or request authenticated resources in
+    JSON format.
+    """
+    schemas = {}
+    for resource_name, resource_config in app.config['DOMAIN'].items():
+        # skip versioned shadow collections
+        if resource_name.endswith(config.VERSIONS):
+            continue
+        # skip internal resources
+        internal = resource_config.get('internal_resource', False)
+        if internal:
+            continue
+        # skip resources for which request does not have read authorization
+        auth = resource_auth(resource_name)
+        if auth and request.method not in resource_config['public_methods']:
+            roles = list(resource_config['allowed_roles'])
+            roles += resource_config['allowed_read_roles']
+            if not auth.authorized(roles, resource_name, request.method):
+                continue
+        # otherwise include this resource in domain wide schema response
+        schemas[resource_name] = resource_config['schema']
+
+    return send_response(None, (schemas,))

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -22,7 +22,8 @@ from werkzeug.serving import WSGIRequestHandler
 import eve
 from eve.defaults import build_defaults
 from eve.endpoints import collections_endpoint, item_endpoint, home_endpoint, \
-    error_endpoint, media_endpoint
+    error_endpoint, media_endpoint, schema_collection_endpoint, \
+    schema_item_endpoint
 from eve.exceptions import ConfigException, SchemaException
 from eve.io.mongo import Mongo, Validator, GridFSMediaStorage, create_index
 from eve.logging import RequestFilter
@@ -155,6 +156,7 @@ class Eve(Flask, Events):
 
         self._init_url_rules()
         self._init_media_endpoint()
+        self._init_schema_endpoint()
 
         if self.config['OPLOG'] is True:
             self._init_oplog()
@@ -878,3 +880,19 @@ class Eve(Flask, Events):
                                             self.config['MEDIA_URL'])
             self.add_url_rule(media_url, 'media',
                               view_func=media_endpoint, methods=['GET'])
+
+    def _init_schema_endpoint(self):
+        """Configures the schema endpoint if set in configuration.
+        """
+        endpoint = self.config['SCHEMA_ENDPOINT']
+
+        if endpoint:
+            schema_url = '%s/%s' % (self.api_prefix, endpoint)
+            # add schema collections url
+            self.add_url_rule(schema_url, 'schema_collection',
+                              view_func=schema_collection_endpoint,
+                              methods=['GET'])
+            # add schema item url
+            self.add_url_rule(schema_url + '/<resource>', 'schema_item',
+                              view_func=schema_item_endpoint,
+                              methods=['GET'])

--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -30,6 +30,9 @@ class BaseJSONEncoder(json.JSONEncoder):
             # should not happen since the only supported date-like format
             # supported at dmain schema level is 'datetime' .
             return obj.isoformat()
+        elif isinstance(obj, set):
+            # convert set objects to encodable lists
+            return list(obj)
         return json.JSONEncoder.default(self, obj)
 
 

--- a/eve/tests/auth.py
+++ b/eve/tests/auth.py
@@ -113,6 +113,14 @@ class TestBasicAuth(TestBase):
         r = self.test_client.delete(self.item_id_url, headers=self.valid_auth)
         self.assert403(r.status_code)
 
+    def test_authorized_schema_access(self):
+        self.app.config['SCHEMA_ENDPOINT'] = 'schema'
+        self.app._init_schema_endpoint()
+
+        r = self.test_client.get('/schema/%s' % self.known_resource,
+                                 headers=self.valid_auth)
+        self.assert200(r.status_code)
+
     def test_unauthorized_home_access(self):
         r = self.test_client.get('/', headers=self.invalid_auth)
         self.assert401(r.status_code)
@@ -135,6 +143,14 @@ class TestBasicAuth(TestBase):
         self.assert401(r.status_code)
         r = self.test_client.delete(self.item_id_url,
                                     headers=self.invalid_auth)
+        self.assert401(r.status_code)
+
+    def test_unauthorized_schema_access(self):
+        self.app.config['SCHEMA_ENDPOINT'] = 'schema'
+        self.app._init_schema_endpoint()
+
+        r = self.test_client.get('/schema/%s' % self.known_resource,
+                                 headers=self.invalid_auth)
         self.assert401(r.status_code)
 
     def test_home_public_methods(self):

--- a/eve/tests/endpoints.py
+++ b/eve/tests/endpoints.py
@@ -302,3 +302,36 @@ class TestEndPoints(TestBase):
         self.assert405(status_code)
         _, status_code = self.delete('/oplog')
         self.assert405(status_code)
+
+    def test_schema_endpoint(self):
+        known_schema_path = '/schema/%s' % self.known_resource
+
+        r = self.test_client.get(known_schema_path)
+        self.assert404(r.status_code)
+
+        self.app.config['SCHEMA_ENDPOINT'] = 'schema'
+        self.app._init_schema_endpoint()
+        r = self.test_client.get(known_schema_path)
+        self.assert200(r.status_code)
+        self.assertEqual(r.mimetype, 'application/json')
+        self.assertEqual(
+            json.loads(r.data),
+            self.app.config['DOMAIN'][self.known_resource]['schema'])
+
+        r = self.test_client.get('/schema/%s' % self.unknown_resource)
+        self.assert404(r.status_code)
+
+        # schema endpoint doesn't reveal internal resources
+        r = self.test_client.get('/schema/internal_transactions')
+        self.assert404(r.status_code)
+
+        # schema endpoint is read-only
+        data = {'field': 'value'}
+        _, status_code = self.patch(known_schema_path, data)
+        self.assert405(status_code)
+        _, status_code = self.put(known_schema_path, data)
+        self.assert405(status_code)
+        _, status_code = self.post(known_schema_path, data)
+        self.assert405(status_code)
+        _, status_code = self.delete(known_schema_path)
+        self.assert405(status_code)


### PR DESCRIPTION
Add 'SCHEMA_ENDPOINT' option, allowing resource schema to be returned from an API endpoint. Defaults to None.