### PR TITLE
move _client_projection() from mongo to DataLayer

### DIFF
--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -15,7 +15,7 @@ from copy import copy
 from flask import request, abort
 from eve.utils import date_to_str
 from eve.auth import auth_field_and_value
-from eve.utils import config, auto_fields
+from eve.utils import config, auto_fields, debug_error_message
 
 
 class BaseJSONEncoder(json.JSONEncoder):
@@ -460,3 +460,23 @@ class DataLayer(object):
                 else:
                     query = {auth_field: request_auth_value}
         return datasource, query, fields, sort
+
+    def _client_projection(self, req):
+        """ Returns a properly parsed client projection if available.
+
+        :param req: a :class:`ParsedRequest` instance.
+
+        .. versionadded:: 0.4
+        """
+        client_projection = {}
+        if req and req.projection:
+            try:
+                client_projection = json.loads(req.projection)
+                if not isinstance(client_projection, dict):
+                    raise Exception('The projection parameter has to be a '
+                                    'dict')
+            except:
+                abort(400, description=debug_error_message(
+                    'Unable to parse `projection` clause'
+                ))
+        return client_projection

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -769,26 +769,6 @@ class Mongo(DataLayer):
         """
         return config.DOMAIN[resource]['mongo_write_concern']
 
-    def _client_projection(self, req):
-        """ Returns a properly parsed client projection if available.
-
-        :param req: a :class:`ParsedRequest` instance.
-
-        .. versionadded:: 0.4
-        """
-        client_projection = {}
-        if req and req.projection:
-            try:
-                client_projection = json.loads(req.projection)
-                if not isinstance(client_projection, dict):
-                    raise Exception('The projection parameter has to be a '
-                                    'dict')
-            except:
-                abort(400, description=debug_error_message(
-                    'Unable to parse `projection` clause'
-                ))
-        return client_projection
-
     def current_mongo_prefix(self, resource=None):
         """ Returns the active mongo_prefix that should be used to retrieve
         a valid PyMongo instance from the cache. If 'self.mongo_prefix' is set


### PR DESCRIPTION
_client_projection() is generic. There is no reason to keep it in
the mongodb drive. By moving it on the DataLayer class we will be
able to drop some (oudated) duplicated code from Eve-SQLAlchemy:

https://github.com/RedTurtle/eve-sqlalchemy/blob/0.4.0a2/eve_sqlalchemy/__init__.py#L325-L340