### PR TITLE
Fix link to Mongo's "capped collections" doc

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1915,7 +1915,7 @@ for unittesting_ and an `extensive documentation`_.
 .. _MongoDB: http://docs.mongodb.org/manual/applications/geospatial-indexes/#geojson-objects
 .. _`geospatial query operators`: http://docs.mongodb.org/manual/reference/operator/query-geospatial/#query-selectors
 .. _$near: http://docs.mongodb.org/manual/reference/operator/query/near/#op._S_near
-.. _`capped collection`: http://docs.mongodb.org/manual/ore/capped-collections/
+.. _`capped collection`: http://docs.mongodb.org/manual/core/capped-collections/
 .. _`Replica Set Oplog`: http://docs.mongodb.org/manual/core/replica-set-oplog/
 .. _`extensions page`: http://python-eve.org/extensions
 .. _source: http://en.wikipedia.org/wiki/JSONP


### PR DESCRIPTION
Found a broken link in the docs...