### PR TITLE
Validate get filters against resource schema

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -116,6 +116,10 @@ uppercase.
                                     disabling filters and whitelisting valid
                                     ones at the local level is the way to go.
 
+``VALIDATE_FILTERS``                Whether to validate the filters against the
+                                    resource schema. Invalid filters will throw
+                                    an exception. Defaults to ``False``.
+
 ``SORTING``                         ``True`` if sorting is supported for ``GET``
                                     requests, otherwise ``False``. Can be
                                     overridden by resource settings. Defaults

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -276,6 +276,11 @@ maintainer can choose to disable them all and/or whitelist allowed ones (see
 by querying on non-indexed fields is a concern, then whitelisting allowed
 filters is the way to go.
 
+You also have the option to validate the incoming filters against the resource's
+schema and refuse to apply the filtering if any filters are invalid, by using the
+``VALIDATE_FILTERING`` system setting (see :ref:`global`)
+
+
 Sorting
 -------
 Sorting is supported as well:

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -141,6 +141,7 @@ HATEOAS = True                  # HATEOAS enabled by default.
 IF_MATCH = True                 # IF_MATCH (ETag match) enabled by default.
 
 ALLOWED_FILTERS = ['*']         # filtering enabled by default
+VALIDATE_FILTERS = False
 SORTING = True                  # sorting enabled by default.
 JSON_SORT_KEYS = False          # json key sorting
 EMBEDDING = True                # embedding enabled by default

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -899,6 +899,56 @@ class TestGet(TestBase):
         response, status = self.get(self.known_resource, where)
         self.assert400(status)
 
+    def test_get_nested_filter_operators_unvalidated(self):
+        """ test that nested filter operators are working correctly.
+        """
+        where = ''.join(('?where={"$and":[{"$or":[{"fldA":"valA"},',
+                    '{"fldB":"valB"}]},{"fld2":"val2"}]}'))
+        response, status = self.get(self.known_resource, where)
+        self.assert200(status)
+
+    def test_get_nested_filter_operators_validated(self):
+        """ test that nested filter operators are working correctly.
+        """
+        self.app.config['VALIDATE_FILTERS'] = True
+
+        where = ''.join(('?where={"$and":[{"$or":[{"fldA":"valA"},',
+                    '{"fldB":"valB"}]},{"fld2":"val2"}]}'))
+        response, status = self.get(self.known_resource, where)
+        self.assert400(status)
+
+        where = ''.join(('?where={"$and":[{"$or":[{"role":',
+                   '["agent","client"]},{"key1":"str"}]}, {"prog":1}]}'))
+        response, status = self.get(self.known_resource, where)
+        self.assert200(status)
+
+    def test_get_invalid_where_fields(self):
+        """ test that checks all fields of the where clause to be valid
+           resource fields according to the resource schema.
+        """
+        self.app.config['VALIDATE_FILTERS'] = True
+
+        # test for an outright missing/invalid field present
+        where = '?where={"$and": [{"bad_field": "val"}, {"fld2": "val2"}]}'
+        response, status = self.get(self.known_resource, where)
+        self.assert400(status)
+
+        # test for resource field not validating correctly (prog is number)
+        where = '?where={"prog": "stringValue"}'
+        response, status = self.get(self.known_resource, where)
+        self.assert400(status)
+
+        # test for resource field validating correctly (key1 is string)
+        where = '?where={"key1": "qwerty"}'
+        response, status = self.get(self.known_resource, where)
+        self.assert200(status)
+
+        # test for nested resource field validating correctly
+        # (location is dict)
+        where = '?where={"location":{"address":"str 1","city":"SomeCity"}}'
+        response, status = self.get(self.known_resource, where)
+        self.assert200(status)
+
     def test_get_lookup_field_as_string(self):
         # Test that a resource where 'item_lookup_field' is set to a field
         # of string type and which value is castable to a ObjectId is still

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -14,6 +14,7 @@ import sys
 import eve
 import hashlib
 import werkzeug.exceptions
+from cerberus import Validator
 from copy import copy
 from flask import request
 from flask import current_app as app
@@ -373,7 +374,7 @@ def validate_filters(where, resource):
 
     def validate_filter(filter):
         for key, value in filter.items():
-            if key not in allowed:
+            if '*' not in allowed and key not in allowed:
                 return "filter on '%s' not allowed" % key
 
             if key in ('$or', '$and', '$nor'):
@@ -386,12 +387,23 @@ def validate_filters(where, resource):
                     r = validate_filter(v)
                     if r:
                         return r
-            elif isinstance(value, dict):
-                r = validate_filter(value)
-                if r:
-                    return r
+            else:
+                if config.VALIDATE_FILTERS:
+                    res_schema = config.DOMAIN[resource]['schema']
+                    if key not in res_schema:
+                        return "filter on '%s' is invalid"
+                    else:
+                        field_schema = res_schema.get(key)
+                        v = Validator({key: field_schema})
+                        if not v.validate({key: value}):
+                            return "filter on '%s' is invalid"
+                        else:
+                            return None
 
-    return validate_filter(where) if '*' not in allowed else None
+    if '*' in allowed and not config.VALIDATE_FILTERS:
+        return None
+
+    return validate_filter(where)
 
 
 def auto_fields(resource):


### PR DESCRIPTION
This should take car of #728.

I included a setting called VALIDATE_FILTER, since the existing code made the assumption that the filter values can be anything, so if the default was to check the validity of the filtering, then a ton of test cases were failing.

Also added some extra test cases, with nested resource attributes and ($and, $or, $nor) operators.