### PR TITLE
Pass transparent_schema_rules option to Cerberus Validator

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Version 0.6.1
 
 Not released.
 
+- New: ``TRANSPARENT_SCHEMA_RULES`` enables/disables schema validation
+  globally and ``transparent_schema_rules`` per resource (Florian Rathgeber)
 - New: ``ALLOW_OVERRIDE_HTTP_METHOD`` enables/disables support for overriding
   request methods with ``X-HTTP-Method-Override`` headers (Julian Hille).
 - Fix: dependendencies on sub-document fields always return 422. Closes #706.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -328,6 +328,9 @@ uppercase.
                                     :ref:`unknown` for more information.
                                     Defaults to ``False``.
 
+``TRANSPARENT_SCHEMA_RULES``        When ``True``, this option globally disables
+                                    :ref:`schema_validation` for any API endpoint.
+
 ``PROJECTION``                      When ``True``, this option enables the
                                     :ref:`projections` feature. Can be
                                     overridden by resource settings. Defaults
@@ -858,6 +861,9 @@ always lowercase.
                                 Use with caution. Locally overrides
                                 ``ALLOW_UNKNOWN``. See :ref:`unknown` for more
                                 information. Defaults to ``False``.
+
+``transparent_schema_rules``    When ``True``, this option disables
+                                :ref:`schema_validation` for the endpoint.
 
 ``projection``                  When ``True``, this option enables the
                                 :ref:`projections` feature. Locally overrides

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -49,6 +49,8 @@ extensible. As a matter of fact, Eve's MongoDB data-layer itself extends
 Cerberus validation, implementing the ``unique`` and ``data_relation``
 constraints and the ``ObjectId`` data type on top of the standard rules.
 
+.. _custom_validation_rules:
+
 Custom Validation Rules
 ------------------------
 Suppose that in your specific and very peculiar use case, a certain value can
@@ -173,6 +175,23 @@ a payload like this will be accepted:
     Use this feature with extreme caution. Also be aware that, when this
     option is enabled, clients will be capable of actually `adding` fields via
     PATCH (edit).
+
+.. _schema_validation:
+
+Schema validation
+-----------------
+
+By default, schemas are validated to ensure they conform to the structure
+documented in :ref:`schema`.
+
+There are two ways to deal with non-conforming schemas:
+
+1.  Add :ref:`custom_validation_rules` for non-conforming keys used in the
+    schema.
+
+2.  Set the global option ``TRANSPARENT_SCHEMA_RULES`` to disable schema
+    validation globally or the resource option ``transparent_schema_rules``
+    to disable schema validation for a given endpoint.
 
 .. _Cerberus: http://python-cerberus.org
 .. _`source code`: https://github.com/nicolaiarocci/eve/blob/develop/eve/io/mongo/validation.py

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -214,6 +214,9 @@ AUTH_FIELD = None
 # don't allow unknown key/value pairs for POST/PATCH payloads.
 ALLOW_UNKNOWN = False
 
+# don't ignore unknown schema rules (raise SchemaError)
+TRANSPARENT_SCHEMA_RULES = False
+
 # Rate limits are disabled by default. Needs a running redis-server.
 RATE_LIMIT_GET = None
 RATE_LIMIT_POST = None

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -568,6 +568,8 @@ class Eve(Flask, Events):
         settings.setdefault('auth_field',
                             self.config['AUTH_FIELD'])
         settings.setdefault('allow_unknown', self.config['ALLOW_UNKNOWN'])
+        settings.setdefault('transparent_schema_rules',
+                            self.config['TRANSPARENT_SCHEMA_RULES'])
         settings.setdefault('extra_response_fields',
                             self.config['EXTRA_RESPONSE_FIELDS'])
         settings.setdefault('mongo_write_concern',

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -33,10 +33,11 @@ class Validator(Validator):
                    documentation.
     :param resource: the resource name.
 
-    .. versionchanged:: 0.6.2
+    .. versionchanged:: 0.6.1
        __init__ signature update for cerberus v0.8.1 compatibility.
-       Remove support for 'transparent_schema_rules' in favor of explicit
-       validators for rules unsupported by cerberus.
+       Disable 'transparent_schema_rules' by default in favor of explicit
+       validators for rules unsupported by cerberus. This can be overridden
+       globally or on a per-resource basis through a config option.
 
     .. versionchanged:: 0.5
        Support for _original_document

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -50,8 +50,8 @@ class Validator(Validator):
        Support for 'transparent_schema_rules' introduced with Cerberus 0.0.3,
        which allows for insertion of 'default' values in POST requests.
     """
-    def __init__(self, schema=None, resource=None,
-                 transparent_schema_rules=False, allow_unknown=False):
+    def __init__(self, schema=None, resource=None, allow_unknown=False,
+                 transparent_schema_rules=False):
         self.resource = resource
         self._id = None
         self._original_document = None

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -50,14 +50,20 @@ class Validator(Validator):
        Support for 'transparent_schema_rules' introduced with Cerberus 0.0.3,
        which allows for insertion of 'default' values in POST requests.
     """
-    def __init__(self, schema=None, resource=None, allow_unknown=False):
+    def __init__(self, schema=None, resource=None,
+                 transparent_schema_rules=False, allow_unknown=False):
         self.resource = resource
         self._id = None
         self._original_document = None
         schema = self._remove_unique_rules_on_fields_with_unique_index(schema)
-        super(Validator, self).__init__(schema)
         if resource:
-            self.allow_unknown = config.DOMAIN[resource]['allow_unknown']
+            transparent_schema_rules = \
+                config.DOMAIN[resource]['transparent_schema_rules']
+            allow_unknown = config.DOMAIN[resource]['allow_unknown']
+        super(Validator, self).__init__(
+            schema,
+            transparent_schema_rules=transparent_schema_rules,
+            allow_unknown=allow_unknown)
 
     def _remove_unique_rules_on_fields_with_unique_index(self, schema):
         # TODO: Actually do what the function name suggests. This version just

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -225,6 +225,8 @@ class TestConfig(TestBase):
                          self.app.config['AUTH_FIELD'])
         self.assertEqual(settings['allow_unknown'],
                          self.app.config['ALLOW_UNKNOWN'])
+        self.assertEqual(settings['transparent_schema_rules'],
+                         self.app.config['TRANSPARENT_SCHEMA_RULES'])
         self.assertEqual(settings['extra_response_fields'],
                          self.app.config['EXTRA_RESPONSE_FIELDS'])
         self.assertEqual(settings['mongo_write_concern'],

--- a/eve/tests/io/mongo.py
+++ b/eve/tests/io/mongo.py
@@ -120,6 +120,10 @@ class TestMongoValidator(TestCase):
         v = Validator(schema, transparent_schema_rules=True)
         self.assertTrue(v.transparent_schema_rules)
 
+    def test_transparent_rules_accept_invalid_schema(self):
+        schema = {'a_field': {'foo': 'bar'}}
+        Validator(schema, transparent_schema_rules=True)
+
     def test_geojson_not_compilant(self):
         schema = {'location': {'type': 'point'}}
         doc = {'location': [10.0, 123.0]}

--- a/eve/tests/io/mongo.py
+++ b/eve/tests/io/mongo.py
@@ -3,6 +3,7 @@
 from unittest import TestCase
 from bson import ObjectId
 from datetime import datetime
+from cerberus import SchemaError
 from eve.io.mongo.parser import parse, ParseError
 from eve.io.mongo import Validator, Mongo, MongoJSONEncoder
 from eve.tests import TestBase
@@ -109,6 +110,10 @@ class TestMongoValidator(TestCase):
         schema = {'a_field': {'type': 'string'}}
         v = Validator(schema)
         self.assertFalse(v.transparent_schema_rules)
+
+    def test_reject_invalid_schema(self):
+        schema = {'a_field': {'foo': 'bar'}}
+        self.assertRaises(SchemaError, lambda: Validator(schema))
 
     def test_enable_transparent_rules(self):
         schema = {'a_field': {'type': 'string'}}

--- a/eve/tests/io/mongo.py
+++ b/eve/tests/io/mongo.py
@@ -110,6 +110,11 @@ class TestMongoValidator(TestCase):
         v = Validator(schema)
         self.assertFalse(v.transparent_schema_rules)
 
+    def test_enable_transparent_rules(self):
+        schema = {'a_field': {'type': 'string'}}
+        v = Validator(schema, transparent_schema_rules=True)
+        self.assertTrue(v.transparent_schema_rules)
+
     def test_geojson_not_compilant(self):
         schema = {'location': {'type': 'point'}}
         doc = {'location': [10.0, 123.0]}


### PR DESCRIPTION
This allows enabling transparent_schema_rules by setting either the global option TRANSPARENT_SCHEMA_RULES or the resource level option transparent_schema_rules.

Note that this option *must* be passed to the superclass constructor and cannot be set afterwards since validation of the schema happens on construction. This requires some minor refactoring of the eve.io.mongo.Validation constructor.