### PR TITLE
Use python 2 for flake8-tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,5 @@ commands=python setup.py test {posargs}
 
 [testenv:flake8]
 deps=flake8
+basepython=python2
 commands=flake8 --ignore=E731 eve {posargs}


### PR DESCRIPTION
There's an assignment of 'basestring' for to compatibility of both
python 2 and python 3. This causes flake8 to fail when executed with python 3
due to an unknown name.
This commit configures tox to run flake8 with python 2 even on systems
were python 3 is the default, to avoid problems here.