### PR TITLE
Allow other parameters to be part of urls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ Patches and Contributions
 - Mayur Dhamanwala
 - Mikael Berg
 - mmizotin
+- Mugur Rus
 - Nathan Reynolds
 - Niall Donegan
 - Nick Park

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -11,6 +11,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import math
+from werkzeug import MultiDict
 from flask import current_app as app, abort, request
 from .common import ratelimit, epoch, pre_event, resolve_embedded_fields, \
     build_response_document, resource_link, document_link, last_updated
@@ -390,8 +391,10 @@ def _pagination_links(resource, req, documents_count, document_id=None):
     if config.DOMAIN[resource]['versioning'] is True:
         version = request.args.get(config.VERSION_PARAM)
 
+    other_params = _other_params(req.args)
     # construct the default links
-    q = querydef(req.max_results, req.where, req.sort, version, req.page)
+    q = querydef(req.max_results, req.where, req.sort, version, req.page,
+                 other_params)
     resource_title = config.DOMAIN[resource]['resource_title']
     _links = {'parent': home_link(),
               'self': {'title': resource_title,
@@ -426,7 +429,7 @@ def _pagination_links(resource, req, documents_count, document_id=None):
         _pagination_link = _links['self']['href'].split('?')[0]
         if req.page * req.max_results < documents_count:
             q = querydef(req.max_results, req.where, req.sort, version,
-                         req.page + 1)
+                         req.page + 1, other_params)
             _links['next'] = {'title': 'next page', 'href': '%s%s' %
                               (_pagination_link, q)}
 
@@ -438,17 +441,29 @@ def _pagination_links(resource, req, documents_count, document_id=None):
             last_page = int(math.ceil(documents_count /
                                       float(req.max_results)))
             q = querydef(req.max_results, req.where, req.sort, version,
-                         last_page)
+                         last_page, other_params)
             _links['last'] = {'title': 'last page', 'href': '%s%s'
                               % (_pagination_link, q)}
 
         if req.page > 1:
             q = querydef(req.max_results, req.where, req.sort, version,
-                         req.page - 1)
+                         req.page - 1, other_params)
             _links['prev'] = {'title': 'previous page', 'href': '%s%s' %
                               (_pagination_link, q)}
 
     return _links
+
+
+def _other_params(args):
+    """ Returns a multidict of params that are not used internally by Eve.
+
+    :param args: multidict containing the request parameters
+    """
+    default_params = [config.QUERY_WHERE, config.QUERY_SORT,
+                      config.QUERY_PAGE, config.QUERY_MAX_RESULTS,
+                      config.QUERY_EMBEDDED, config.QUERY_PROJECTION]
+    return MultiDict([(key, value) for key, value in args.items()
+                      if key not in default_params])
 
 
 def _meta_links(req, count):

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -462,8 +462,8 @@ def _other_params(args):
     default_params = [config.QUERY_WHERE, config.QUERY_SORT,
                       config.QUERY_PAGE, config.QUERY_MAX_RESULTS,
                       config.QUERY_EMBEDDED, config.QUERY_PROJECTION]
-    return MultiDict([(key, value) for key, value in args.items()
-                      if key not in default_params])
+    return MultiDict((key, value) for key, values in args.lists()
+                     for value in values if key not in default_params)
 
 
 def _meta_links(req, count):

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -13,6 +13,10 @@ from eve.tests.test_settings import MONGO_PASSWORD, MONGO_USERNAME, \
     MONGO_DBNAME, DOMAIN, MONGO_HOST, MONGO_PORT
 from eve import ISSUES, ETAG
 from eve.utils import date_to_str
+try:
+    from urlparse import parse_qs, urlparse
+except ImportError:
+    from urllib.parse import parse_qs, urlparse
 
 
 class ValueStack(object):
@@ -291,6 +295,14 @@ class TestMinimal(unittest.TestCase):
                             in link['href'])
         else:
             self.assertTrue('last' not in links)
+
+    def assertCustomParams(self, link, params):
+        self.assertTrue('href' in link)
+        url_params = parse_qs(urlparse(link['href']).query)
+        for param, values in params.lists():
+            self.assertTrue(param in url_params)
+            for value in values:
+                self.assertTrue(value in url_params[param])
 
     def assert400(self, status):
         self.assertEqual(status, 400)

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -265,8 +265,8 @@ def querydef(max_results=config.PAGINATION_DEFAULT, where=None, sort=None,
         else ''
     max_results_part = '%s=%s' % (config.QUERY_MAX_RESULTS, max_results) \
         if max_results != config.PAGINATION_DEFAULT else ''
-    other_params_part = ''.join(['&%s=%s' % (key, value) for key, value
-                                 in other_params.items()])
+    other_params_part = ''.join('&%s=%s' % (param, value) for param, values
+                                in other_params.lists() for value in values)
 
     # remove sort set by Eve if version is set
     if version and sort is not None:

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -21,6 +21,7 @@ from flask import current_app as app
 from datetime import datetime, timedelta
 from bson.json_util import dumps
 from eve import RFC1123_DATE_FORMAT
+from werkzeug import MultiDict
 
 
 class Config(object):
@@ -240,7 +241,7 @@ def api_prefix(url_prefix=None, api_version=None):
 
 
 def querydef(max_results=config.PAGINATION_DEFAULT, where=None, sort=None,
-             version=None, page=None):
+             version=None, page=None, other_params=MultiDict()):
     """ Returns a valid query string.
 
     :param max_results: `max_result` part of the query string. Defaults to
@@ -249,6 +250,8 @@ def querydef(max_results=config.PAGINATION_DEFAULT, where=None, sort=None,
     :param sort: `sort` part of the query string. Defaults to None.
     :param page: `version` part of the query string. Defaults to None.
     :param page: `page` part of the query string. Defaults to None.
+    :param other_params: dictionary of parameters that are not used
+                         internally by Eve
 
     .. versionchanged:: 0.5
        Support for customizable query parameters.
@@ -262,6 +265,8 @@ def querydef(max_results=config.PAGINATION_DEFAULT, where=None, sort=None,
         else ''
     max_results_part = '%s=%s' % (config.QUERY_MAX_RESULTS, max_results) \
         if max_results != config.PAGINATION_DEFAULT else ''
+    other_params_part = ''.join(['&%s=%s' % (key, value) for key, value
+                                 in other_params.items()])
 
     # remove sort set by Eve if version is set
     if version and sort is not None:
@@ -269,7 +274,8 @@ def querydef(max_results=config.PAGINATION_DEFAULT, where=None, sort=None,
             if sort != '[("%s", 1)]' % config.VERSION else ''
 
     return ('?' + ''.join([max_results_part, where_part, sort_part,
-                           version_part, page_part]).lstrip('&')).rstrip('?')
+                           version_part, page_part, other_params_part])
+            .lstrip('&')).rstrip('?')
 
 
 def document_etag(value, ignore_fields=None):


### PR DESCRIPTION
Parameters not recognised by Eve are stripped from HATEOAS URLs.
This change adds those parameters to HATEOAS URLs.

E.g.: I want to implement a different way of filtering content,
instead of using where:
?start_date=2014-01-25&search_for=foo