### PR TITLE
Option to write full object to the oplog on POST

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -597,6 +597,10 @@ uppercase.
                                     Defaults to ``['DELETE', 'POST', 'PATCH',
                                     'PUT']``.
 
+``OPLOG_CHANGE_METHODS``            List of HTTP methods which operations
+                                    will include changes into the :ref:`oplog` entry.
+                                    Defaults to ``['DELETE','PATCH', 'PUT']``.
+
 ``OPLOG_ENDPOINT``                  Name of the :ref:`oplog` endpoint. If the 
                                     endpoint is enabled it can be configured
                                     like any other API endpoint. Set it to

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1840,6 +1840,7 @@ Six settings are dedicated to the OpLog:
 - ``OPLOG_METHODS`` is a list of HTTP methods to be logged. Defaults to all of them.
 - ``OPLOG_ENDPOINT`` is the endpoint name. Defaults to ``None``.
 - ``OPLOG_AUDIT`` if enabled, IP addresses and changes are also logged. Defaults to ``True``.
+- ``OPLOG_CHANGE_METHODS`` determines which methods will log changes. Defaults to ['PATCH', 'PUT', 'DELETE'].
 
 As you can see the oplog feature is turned off by default. Also, since
 ``OPLOG_ENDPOINT`` defaults to ``None``, even if you switch the feature on no

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -166,6 +166,9 @@ OPLOG_METHODS = ['DELETE',
                  'POST',
                  'PATCH',
                  'PUT']         # oplog logs all operations by default.
+OPLOG_CHANGE_METHODS = ['DELETE',
+                        'PATCH',
+                        'PUT']  # oplog logs only changes by default (not full content on POST).
 
 RESOURCE_METHODS = ['GET']
 ITEM_METHODS = ['GET']

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -168,7 +168,7 @@ OPLOG_METHODS = ['DELETE',
                  'PUT']         # oplog logs all operations by default.
 OPLOG_CHANGE_METHODS = ['DELETE',
                         'PATCH',
-                        'PUT']  # oplog logs only changes by default (not full content on POST).
+                        'PUT']  # methods which write changes to the oplog
 
 RESOURCE_METHODS = ['GET']
 ITEM_METHODS = ['GET']

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -1040,9 +1040,10 @@ def oplog_push(resource, document, op, id=None):
             # https://stackoverflow.com/questions/22868900/how-do-i-safely-get-the-users-real-ip-address-in-flask-using-mod-wsgi
             entry['ip'] = request.remote_addr
 
-            if op in ('PATCH', 'PUT', 'DELETE'):
+            if op in config.OPLOG_CHANGE_METHODS:
                 # these fields are already contained in 'entry'.
                 del(update[config.LAST_UPDATED])
+                del(update[config.DATE_CREATED])
                 # legacy documents (v0.4 or less) could be missing the etag
                 # field
                 if config.ETAG in update:

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -1043,7 +1043,6 @@ def oplog_push(resource, document, op, id=None):
             if op in config.OPLOG_CHANGE_METHODS:
                 # these fields are already contained in 'entry'.
                 del(update[config.LAST_UPDATED])
-                del(update[config.DATE_CREATED])
                 # legacy documents (v0.4 or less) could be missing the etag
                 # field
                 if config.ETAG in update:

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -57,7 +57,9 @@ class TestConfig(TestBase):
                                                             'POST',
                                                             'PATCH',
                                                             'PUT'])
-
+        self.assertEqual(self.app.config['OPLOG_CHANGE_METHODS'],['DELETE',
+                                                                  'PATCH',
+                                                                  'PUT'])
         self.assertEqual(self.app.config['QUERY_WHERE'], 'where')
         self.assertEqual(self.app.config['QUERY_PROJECTION'], 'projection')
         self.assertEqual(self.app.config['QUERY_SORT'], 'sort')

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -57,9 +57,9 @@ class TestConfig(TestBase):
                                                             'POST',
                                                             'PATCH',
                                                             'PUT'])
-        self.assertEqual(self.app.config['OPLOG_CHANGE_METHODS'],['DELETE',
-                                                                  'PATCH',
-                                                                  'PUT'])
+        self.assertEqual(self.app.config['OPLOG_CHANGE_METHODS'], ['DELETE',
+                                                                   'PATCH',
+                                                                   'PUT'])
         self.assertEqual(self.app.config['QUERY_WHERE'], 'where')
         self.assertEqual(self.app.config['QUERY_PROJECTION'], 'projection')
         self.assertEqual(self.app.config['QUERY_SORT'], 'sort')

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -250,7 +250,7 @@ class TestOpLogBase(TestBase):
         self.assertTrue('o' in entry)
         self.assertEqual(entry['o'], op)
         self.assertTrue('127.0.0.1' in entry['ip'])
-        if op in config.OPLOG_CHANGE_METHODS:
+        if op in self.app.config['OPLOG_CHANGE_METHODS']:
             self.assertTrue('c' in entry)
 
 
@@ -259,6 +259,8 @@ class TestOpLogEndpointDisabled(TestOpLogBase):
         super(TestOpLogEndpointDisabled, self).setUp()
 
         self.app.config['OPLOG'] = True
+        from eve.default_settings import OPLOG_CHANGE_METHODS
+        self.app.config['OPLOG_CHANGE_METHODS'] = OPLOG_CHANGE_METHODS
         self.oplog_reset()
 
     def test_post_oplog(self):

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -250,7 +250,7 @@ class TestOpLogBase(TestBase):
         self.assertTrue('o' in entry)
         self.assertEqual(entry['o'], op)
         self.assertTrue('127.0.0.1' in entry['ip'])
-        if op in ('PATCH', 'PUT', 'DELETE'):
+        if op in config.OPLOG_CHANGE_METHODS:
             self.assertTrue('c' in entry)
 
 


### PR DESCRIPTION
I use oplog to track object change history. Currently, the 'c' field is not written on document creation via POST, thus it is hard to view the initial document state.

This pull request makes methods which write changes to oplog configurable with option OPLOG_CHANGE_METHODS, with the default value ['DELETE', 'PATCH', 'PUT'] corresponding to the current behavior.

I'm not sure about the naming though.