### PR TITLE
Validator is not set when skip_validation is true

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ allows to effortlessly build and deploy highly customizable, fully featured
 RESTful Web Services.
 
 Eve is powered by Flask, Redis, Cerberus, Events and offers support for both
-MongoDB and SQL backends.
+MongoDB and SQL backends
 
 The codebase is thoroughly tested under Python 2.6, 2.7, 3.3, 3.4 and PyPy.
 

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -135,8 +135,7 @@ def patch_internal(resource, payload=None, concurrency_check=False,
 
     resource_def = app.config['DOMAIN'][resource]
     schema = resource_def['schema']
-    if not skip_validation:
-        validator = app.validator(schema, resource)
+    validator = app.validator(schema, resource)
 
     object_id = original[resource_def['id_field']]
     last_modified = None


### PR DESCRIPTION
Fixes issue introduced with 0b2ae5a928c18f53c598ae2ba4536df6f9e175f4 in which case when the ```patch_internal``` method was called with ```skip_validation=True``` the ```validator``` on line 139 will *not* be instantiated, but it will try to be accessed on line 163 causing a:

    Traceback (most recent call last):
      File "/usr/local/lib/python2.7/dist-packages/eve/methods/patch.py", line 163, in patch_internal
        updates = validator.document
    UnboundLocalError: local variable 'validator' referenced before assignment
    ERROR:eve:local variable 'validator' referenced before assignment