### PR TITLE
Skip any null value from attempting serialization (Fixes #772)

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -328,6 +328,8 @@ def serialize(document, resource=None, schema=None, fields=None):
         if not fields:
             fields = document.keys()
         for field in fields:
+            if document[field] is None:
+                continue
             if field in schema:
                 field_schema = schema[field]
                 field_type = field_schema.get('type')
@@ -341,7 +343,7 @@ def serialize(document, resource=None, schema=None, fields=None):
                             if type(subdocument) is not dict:
                                 # value is not a dict - continue serialization
                                 # error will be reported by validation if
-                                # appropriate (could be allowed nullable dict)
+                                # appropriate
                                 continue
                             elif 'schema' in field_schema:
                                 serialize(subdocument,

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -168,6 +168,25 @@ class TestSerializer(TestBase):
                 self.assertTrue(False, "Serializing null dictionaries should "
                                        "not raise an exception.")
 
+    def test_serialize_null_list(self):
+        schema = {
+            'nullable_list': {
+                'type': 'list',
+                'nullable': True,
+                'schema': {
+                    'type': 'objectid'
+                }
+            }
+        }
+        doc = {
+            'nullable_list': None
+        }
+        with self.app.app_context():
+            try:
+                serialize(doc, schema=schema)
+            except Exception:
+                self.fail('Serializing null lists should not raise an exception')
+
 
 class TestNormalizeDottedFields(TestBase):
     def test_normalize_dotted_fields(self):

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -185,7 +185,8 @@ class TestSerializer(TestBase):
             try:
                 serialize(doc, schema=schema)
             except Exception:
-                self.fail('Serializing null lists should not raise an exception')
+                self.fail('Serializing null lists'
+                          ' should not raise an exception')
 
 
 class TestNormalizeDottedFields(TestBase):


### PR DESCRIPTION
On a side note, given the strong contract that this PR enforces, the null guards in the serializers could (and should, IMHO) be removed. 