### PR TITLE
Add missing serializer for fields of type number.

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -66,6 +66,7 @@ class Mongo(DataLayer):
         'datetime': str_to_date,
         'integer': lambda value: int(value) if value is not None else None,
         'float': lambda value: float(value) if value is not None else None,
+        'number': lambda val: json.loads(val) if val is not None else None
     }
 
     # JSON serializer is a class attribute. Allows extensions to replace it

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -180,7 +180,9 @@ class TestSerializer(TestBase):
             }
             with self.app.app_context():
                 serialized = serialize(doc, schema=schema)
-                self.assertIsInstance(serialized['anumber'], expected_type)
+                self.assertTrue(
+                    isinstance(serialized['anumber'], expected_type)
+                )
 
 
 class TestNormalizeDottedFields(TestBase):

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -168,6 +168,20 @@ class TestSerializer(TestBase):
                 self.assertTrue(False, "Serializing null dictionaries should "
                                        "not raise an exception.")
 
+    def test_serialize_number(self):
+        schema = {
+            'anumber': {
+                'type': 'number',
+            }
+        }
+        for expected_type, value in [(int, '35'), (float, '3.5')]:
+            doc = {
+                'anumber': value
+            }
+            with self.app.app_context():
+                serialized = serialize(doc, schema=schema)
+                self.assertIsInstance(serialized['anumber'], expected_type)
+
 
 class TestNormalizeDottedFields(TestBase):
     def test_normalize_dotted_fields(self):

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -270,6 +270,17 @@ class TestPatch(TestBase):
         self.assert200(status)
         self.assertTrue('OK' in r[STATUS])
 
+    def test_patch_x_www_form_urlencoded_number_serialization(self):
+        del(self.domain['contacts']['schema']['ref']['required'])
+        field = 'anumber'
+        test_value = 3.5
+        changes = {field: test_value}
+        headers = [('If-Match', self.item_etag)]
+        r, status = self.parse_response(self.test_client.patch(
+            self.item_id_url, data=changes, headers=headers))
+        self.assert200(status)
+        self.assertTrue('OK' in r[STATUS])
+
     def test_patch_referential_integrity(self):
         data = {"person": self.unknown_item_id}
         headers = [('If-Match', self.invoice_etag)]

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -217,6 +217,17 @@ class TestPost(TestBase):
         self.assertTrue('OK' in r[STATUS])
         self.assertPostResponse(r)
 
+    def test_post_x_www_form_urlencoded_number_serialization(self):
+        del(self.domain['contacts']['schema']['ref']['required'])
+        test_field = "anumber"
+        test_value = 34
+        data = {test_field: test_value}
+        r, status = self.parse_response(self.test_client.post(
+            self.known_resource_url, data=data))
+        self.assert201(status)
+        self.assertIn('OK', r[STATUS])
+        self.assertPostResponse(r)
+
     def test_post_referential_integrity(self):
         data = {"person": self.unknown_item_id}
         r, status = self.post('/invoices/', data=data)

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -225,7 +225,7 @@ class TestPost(TestBase):
         r, status = self.parse_response(self.test_client.post(
             self.known_resource_url, data=data))
         self.assert201(status)
-        self.assertIn('OK', r[STATUS])
+        self.assertTrue('OK' in r[STATUS])
         self.assertPostResponse(r)
 
     def test_post_referential_integrity(self):

--- a/eve/tests/methods/put.py
+++ b/eve/tests/methods/put.py
@@ -71,6 +71,17 @@ class TestPut(TestBase):
         self.assert200(status)
         self.assertTrue('OK' in r[STATUS])
 
+    def test_put_x_www_form_urlencoded_number_serialization(self):
+        del(self.domain['contacts']['schema']['ref']['required'])
+        field = 'anumber'
+        test_value = 41
+        changes = {field: test_value}
+        headers = [('If-Match', self.item_etag)]
+        r, status = self.parse_response(self.test_client.put(
+            self.item_id_url, data=changes, headers=headers))
+        self.assert200(status)
+        self.assertTrue('OK' in r[STATUS])
+
     def test_put_referential_integrity(self):
         data = {"person": self.unknown_item_id}
         headers = [('If-Match', self.invoice_etag)]

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -143,6 +143,9 @@ contacts = {
         },
         'afloat': {
             'type': 'float',
+        },
+        'anumber': {
+            'type': 'number'
         }
     }
 }


### PR DESCRIPTION
The serializers of int, float and number are required when using
Eve through x-www-urlencode requests. Added some test cases that
covers this dependency.