### PR TITLE
Add support for extended TokenAuth header

### DIFF
--- a/eve/auth.py
+++ b/eve/auth.py
@@ -241,8 +241,13 @@ class TokenAuth(BasicAuth):
                               string or a list of roles.
         :param resource: resource being requested.
         """
-        auth = request.authorization
-        return auth and self.check_auth(auth.username, allowed_roles, resource,
+	if request.authorization:
+       	    auth = request.authorization.username 
+        else:
+            auth = request.headers.get('Authorization').strip()
+            if auth.startswith('Token') or auth.startswith('token'):
+                auth = auth.split(" ")[1] 
+        return auth and self.check_auth(auth, allowed_roles, resource,
                                         method)
 
 

--- a/eve/auth.py
+++ b/eve/auth.py
@@ -241,7 +241,7 @@ class TokenAuth(BasicAuth):
                               string or a list of roles.
         :param resource: resource being requested.
         """
-	if request.authorization:
+        if request.authorization:
        	    auth = request.authorization.username 
         else:
             auth = request.headers.get('Authorization').strip()

--- a/eve/auth.py
+++ b/eve/auth.py
@@ -241,12 +241,12 @@ class TokenAuth(BasicAuth):
                               string or a list of roles.
         :param resource: resource being requested.
         """
-        if request.authorization:
-       	    auth = request.authorization.username 
-        else:
+        auth = request.authorization.username if hasattr(request.authorization, 'username') else None
+        # Werkzeug parse_authorization does not handle "Authorization: <token>" or "Authorization: Token <token>" headers, therefore they should be explicitly handled
+        if not auth and request.headers.get('Authorization'):
             auth = request.headers.get('Authorization').strip()
             if auth.startswith('Token') or auth.startswith('token'):
-                auth = auth.split(" ")[1] 
+                auth = auth.split(' ')[1]
         return auth and self.check_auth(auth, allowed_roles, resource,
                                         method)
 

--- a/eve/auth.py
+++ b/eve/auth.py
@@ -241,8 +241,13 @@ class TokenAuth(BasicAuth):
                               string or a list of roles.
         :param resource: resource being requested.
         """
-        auth = request.authorization.username if hasattr(request.authorization, 'username') else None
-        # Werkzeug parse_authorization does not handle "Authorization: <token>" or "Authorization: Token <token>" headers, therefore they should be explicitly handled
+        auth = None
+        if hasattr(request.authorization, 'username'):
+            auth = request.authorization.username
+        # Werkzeug parse_authorization does not handle
+        # "Authorization: <token>" or
+        # "Authorization: Token <token>"
+        # headers, therefore they should be explicitly handled
         if not auth and request.headers.get('Authorization'):
             auth = request.headers.get('Authorization').strip()
             if auth.startswith('Token') or auth.startswith('token'):

--- a/eve/auth.py
+++ b/eve/auth.py
@@ -226,13 +226,10 @@ class TokenAuth(BasicAuth):
         raise NotImplementedError
 
     def authenticate(self):
-        """ Returns a standard a 401 response that enables basic auth.
-        Override if you want to change the response and/or the realm.
+        """ Returns a standard a 401. Override if you want to change the
+        response.
         """
-        resp = Response(None, 401, {'WWW-Authenticate': 'Basic realm="%s"' %
-                                    __package__})
-        abort(401, description='Please provide proper credentials',
-              response=resp)
+        abort(401, description='Please provide proper credentials')
 
     def authorized(self, allowed_roles, resource, method):
         """ Validates the the current request is allowed to pass through.

--- a/eve/tests/auth.py
+++ b/eve/tests/auth.py
@@ -30,6 +30,10 @@ class ValidTokenAuth(TokenAuth):
                                           allowed_roles else True)
 
 
+class BadTokenAuth(TokenAuth):
+    pass
+
+
 class ValidHMACAuth(HMACAuth):
     def check_auth(self, userid, hmac_hash, headers, data, allowed_roles,
                    resource, method):
@@ -271,6 +275,20 @@ class TestTokenAuth(TestBasicAuth):
 
     def test_custom_auth(self):
         self.assertTrue(isinstance(self.app.auth, ValidTokenAuth))
+
+
+class TestCustomTokenAuth(TestTokenAuth):
+    def setUp(self):
+        super(TestCustomTokenAuth, self).setUp()
+        self.valid_auth = [('Authorization', 'Token test_token'),
+                           self.content_type]
+
+    def test_bad_auth_class(self):
+        self.app = Eve(settings=self.settings_file, auth=BadTokenAuth)
+        self.test_client = self.app.test_client()
+        r = self.test_client.get('/', headers=self.valid_auth)
+        # will fail because check_auth() is not implemented in the custom class
+        self.assert500(r.status_code)
 
 
 class TestHMACAuth(TestBasicAuth):


### PR DESCRIPTION
Namely, when the tokens were passed as "Authorization: <token>" or "Authorization: Token <token>" headers, the werkzeug parse_authorization did not recognize them as valid authorization header, therefore the request.authorization field was empty.

The workaround now considers, in addition to the werkzeug parsed authorization, also a direct manipulation of the "Authorization" header.