### PR TITLE
Allow callables for 'default' in schema

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1178,7 +1178,13 @@ defining the field validation rules. Allowed validation rules are:
 
 ``default``                     The default value for the field. When serving
                                 POST and PUT requests, missing fields will be
-                                assigned the configured default values.
+                                assigned the configured default values. If the
+                                default value is a callable, it is evaluated
+                                before assignment.
+
+                                Callables can even depend on one another, but
+                                a ``RuntimeError`` will be raised if there is a
+                                circular dependency.
 
                                 It works also for types ``dict`` and ``list``.
                                 The latter is restricted and works only for


### PR DESCRIPTION
Allows the use of calculated default values via callables, e.g. lambda functions. They can even depend on one another and use all other values of the document, while circular dependencies are properly detected: a ```RuntimeError``` is raised in this case.

A small example how to use this:
```python
def one_hour_after_value_date(document):
    from datetime import timedelta
    return document['value_date'] + timedelta(hours=1)

RESOURCE_METHODS = ['GET', 'POST']

DOMAIN = {
    'transactions': {
        'schema': {
            'amount': {
                'type': 'integer',
                'required': True
            },
            'expiration_date': {
                'type': 'datetime',
                'default': one_hour_after_value_date
            },
            'value_date': {
                'type': 'datetime',
                'default': lambda doc: doc['_created']
            },
        }
    }
}
```