### PR TITLE
Make app installed as console-script not fail

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -11,7 +11,6 @@
 """
 import inspect
 import os
-import sys
 
 import copy
 from events import Events
@@ -231,7 +230,7 @@ class Eve(Flask, Events):
                 abspath = inspect.getabsfile(
                     inspect.currentframe().f_back.f_back)
                 absdir = os.path.dirname(abspath)
-                pyfile = os.path.join(abspath, self.settings)
+                pyfile = os.path.join(absdir, self.settings)
             try:
                 self.config.from_pyfile(pyfile)
             except IOError:

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -9,6 +9,7 @@
     :copyright: (c) 2016 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
+import inspect
 import os
 import sys
 
@@ -227,7 +228,9 @@ class Eve(Flask, Events):
             if os.path.isabs(self.settings):
                 pyfile = self.settings
             else:
-                abspath = os.path.abspath(os.path.dirname(sys.argv[0]))
+                abspath = inspect.getabsfile(
+                    inspect.currentframe().f_back.f_back)
+                absdir = os.path.dirname(abspath)
                 pyfile = os.path.join(abspath, self.settings)
             try:
                 self.config.from_pyfile(pyfile)


### PR DESCRIPTION
So I am doing all my python apps be deployed with pip install, and when using by console-scripts to launch servers, without this introspection, path will be wrong.

I really thought I had submitted this patch. It is really hacky, and maybe expensive, but just on the initialization.