### PR TITLE
Closes #840: RegEx matches auth token from header

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 docutils==0.12
 flake8==2.3.0
 mccabe==0.3
+nose-parameterized==0.5.0
 pep8==1.5.7
 pip-tools==0.3.5
 pip-review==0.4


### PR DESCRIPTION
This PR introduces a test library called
[nose-parameterized](https://github.com/wolever/nose-parameterized),
which enables pretty flexible parameterized testing. This enabled me to
ensure the new `extract_token` method I wrote for the TokenAuth class
works as expected. I didn't want any unaccounted edge cases.

The `extract_token` method uses the following RegEx to grab the token
from the headers:

```python
match = re.search('token[\s]+(.*)', auth, re.IGNORECASE)
```

It matches anything beginning with the word "token" where the case of its
letters are ignored, followed by 1 or more whitespace characters, followed
by the actual token.

If you'd prefer for the behavior to simply be rolled back to what it
was before `lower()` was added, I am happy to accommodate that as well.

Let me know what you think! Cheers :smile:

PS: I just noticed my autoformatter rearranged the Python import
statements. If this is a problem, I am happy to undo that.