### PR TITLE
Support etag cache validation for versioned documents 

### DIFF
--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -1369,6 +1369,13 @@ class TestGetItem(TestBase):
         self.assert304(r.status_code)
         self.assertTrue(not r.get_data())
 
+        # test that we support weak etags
+        weak_etag = 'W/' + etag
+        r = self.test_client.get(self.item_id_url,
+                                 headers=[('If-None-Match', weak_etag)])
+        self.assert304(r.status_code)
+        self.assertTrue(not r.get_data())
+
     def test_cache_control(self):
         self.assertCacheControl(self.item_id_url)
 

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -613,9 +613,10 @@ class TestCompleteVersioning(TestNormalVersioning):
             self.assertTrue(self.version_field in item)
             self.assertTrue(self.latest_version_field in item)
 
-    def test_getitem_version_new_latest_version_invalidates_cache(self):
-        """Verify that a cached document version is invalidate when the
-        _latest_version field has changed due to creation of a new version
+    def test_getitem_version_new_latest_version_invalidates_if_modified_since(self):
+        """Verify that a cached document version is invalidated via
+        an 'If-Modified-Since' header when the _latest_version field has changed
+        due to creation of a new version
         """
         # get first version and record Last-Modified
         r = self.test_client.get(self.item_id_url + "?version=1")
@@ -635,25 +636,36 @@ class TestCompleteVersioning(TestNormalVersioning):
         # get first version again and confirm Last-Modified and latest version
         # have been updated
         r = self.test_client.get(self.item_id_url + "?version=1", headers=[
-            ('If-None-Match', self.item_etag),
             ('If-Modified-Since', last_modified)])
         document, status = self.parse_response(r)
         self.assert200(status)
         self.assertEqual(document[self.latest_version_field], 2)
 
-    def test_getitem_version_ignores_if_none_match(self):
-        """Verify that cached old version documents cannot be validated by
-        etag alone. It is impossible to catch _latest_version changes to old
-        versioned docs with only etags.
+    def test_getitem_version_new_latest_version_invalidates_if_none_match(self):
+        """Verify that a cached document version is invalidated via
+        an 'If-None-Match' header when the _latest_version field has changed
+        due to creation of a new version
         """
+        # get first version and record ETag
+        r = self.test_client.get(self.item_id_url + "?version=1")
+        document, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertEqual(document[self.latest_version_field], 1)
+        version1_etag = r.headers.get('ETag')
+
+        # put a second version
         response, status = self.put(
             self.item_id_url, data=self.item_change,
             headers=[('If-Match', self.item_etag)])
         self.assertGoodPutPatch(response, status)
 
+        # get first version again and confirm latest version has been updated
         r = self.test_client.get(self.item_id_url + "?version=1", headers=[
-            ('If-None-Match', self.item_etag)])
-        self.assert200(r.status_code)
+            ('If-None-Match', version1_etag)
+        ])
+        document, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertEqual(document[self.latest_version_field], 2)
 
     def test_automatic_fields(self):
         """ Make sure that Eve throws an error if we try to set a versioning

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -161,8 +161,16 @@ def parse_request(resource):
             r.max_results = config.PAGINATION_LIMIT
 
     def etag_parse(challenge):
-        return headers[challenge].replace('\"', '') if challenge in headers \
-            else None
+        if challenge in headers:
+            etag = headers[challenge]
+            # allow weak etags (Eve does not support byte-range requests)
+            if etag.startswith('W/\"'):
+                etag = etag.lstrip('W/')
+            # remove double quotes from challenge etag format to allow direct
+            # string comparison with stored values
+            return etag.replace('\"', '')
+        else:
+            return None
 
     if headers:
         r.if_modified_since = weak_date(headers.get('If-Modified-Since'))


### PR DESCRIPTION
- Support weak ETags, commonly applied by servers transmitting gzipped content.
- Allow old versions to be cache validated using ETags.
Without 'If-None-Match' style cache validation supported, data migrations
that update old versions and correctly compute new ETags, but don't change
updated_at dates, will appear to be valid in client caches even though the
data has been changed.