### PR TITLE
Support ENFORCE_IF_MATCH flag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Patches and Contributions
 - Andrés Martano
 - Antonio Lourenco
 - Arnau Orriols
+- Arthur Burkart
 - Ashley Roach
 - Ben Demaree
 - Bjorn Andersson

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,13 @@ In Development
 Version 0.7
 ~~~~~~~~~~~
 
+- New: If ENFORCE_IF_MATCH option is active, then all requests are expected to
+  include the If-Match or they will be rejected (same as old behavior).
+  However, if ENFORCE_IF_MATCH is disabled, then client determines whether
+  request is conditional. When If-Match is included, then request is
+  conditional, otherwise the request is processed with no conditional checks.
+  (Arthur Burkart)
+
 - New: Allow old document versions to be cache validated using ETags (Nick
   Park).
 
@@ -17,13 +24,13 @@ Version 0.7
 
 - New: ``on_oplog_push`` event is fired when OPLOG is about to be updated.
   Callbacks receive two arguments: ``resource`` (resource name) and ``entries``
-  (list of oplog entries which are about to be written). 
+  (list of oplog entries which are about to be written).
 
 - New: optional ``extra`` field is available for OPLOG entries. Can be updated
   by callbacks hooked to the new ``on_oplog_push`` event.
 
 - New: OPLOG audit now include the username or token when available. Closes
-  #846. 
+  #846.
 
 - New ``get_internal`` and ``getitem_internal`` functions can be used for
   internal GET calls. These methods are not rate limited, authentication is not
@@ -156,9 +163,9 @@ Released on 29 October, 2015
 
 - Dev: fix rate limiting tests so they don't occasionally fail.
 - Dev: make sure connections opened by test suite are properly closed on
-  teardown. 
+  teardown.
 - Dev: use middleware to parse overrides and eventually update request method
-  (Julian Hille). 
+  (Julian Hille).
 - Dev: optimize versioning by building specific versions without deepcopying
   the root document (Nick Park).
 - Dev: ``_client_projection`` method has been moved up from the mongo layer to
@@ -189,7 +196,7 @@ Released on 28 September, 2015
   name, at the Eve homepage (suggested value ``_info``). The info section will
   include Eve server version and API version (API_VERSION, if set).  ``None``
   otherwise, if you do not want to expose any server info. Defaults to ``None``
-  (Stratos Gerakakis). 
+  (Stratos Gerakakis).
 - New: ``id_field`` sets a field used to uniquely identify resource items
   within the database. Locally overrides ``ID_FIELD`` (Dominik Kellner).
 - New: ``UPSERT_ON_PUT`` allows document creation on PUT if the document does
@@ -242,7 +249,7 @@ Released on 28 September, 2015
   endpoint. If URRA is not active on the endpoint, this rule behaves like
   ``unique``. Closes #646.
 - New: ``MEDIA_BASE_URL`` allows to set a custom base URL to be used when
-  ``RETURN_MEDIA_AS_URL`` is active (Henrique Barroso).  
+  ``RETURN_MEDIA_AS_URL`` is active (Henrique Barroso).
 - New: ``SOFT_DELETE`` enables soft deletes when set to ``True`` (Nick Park.)
 - New: ``mongo_indexes`` allows for creation of MongoDB indexes at application
   launch (Pau Freixes.)
@@ -253,9 +260,9 @@ Released on 28 September, 2015
 - New: Support for dot notation in POST, PATCH and PUT methods. Be aware that,
   for PATCH and PUT, if dot notation is used even on just one field, the whole
   sub-document will be replaced. So if this document is stored:
-  
+
   ``{"name": "john", "location": {"city": "New York", "address": "address"}}``
-  
+
   A PATCH like this:
 
     ``{"location.city": "Boston"}``
@@ -265,11 +272,11 @@ Released on 28 September, 2015
     ``{"location": {"city": "a nested city"}}``
 
   Will update the document to:
-  
+
   ``{"name": "john", "location": {"city": "Boston"}}``
 
 - New: JSONP Support (Tim Jacobi.)
-- New: Support for multiple MongoDB databases and/or servers. 
+- New: Support for multiple MongoDB databases and/or servers.
 
   - ``mongo_prefix`` resource setting allows overriding of the default
     ``MONGO`` prefix used when retrieving MongoDB settings from configuration.
@@ -295,7 +302,7 @@ Released on 28 September, 2015
   ``None`` (Olivier Carrère.)
 
 - Change: when HATEOAS is off the home endpoint will respond with ``200 OK``
-  instead of ``404 Not Found`` (Stratos Gerakakis). 
+  instead of ``404 Not Found`` (Stratos Gerakakis).
 - Change: PUT does not return ``404`` if a document URL does not exist. It will
   attempt to create the document instead. Set ``UPSET_ON_PUT`` to ``False`` to
   disable this behaviour and get a ``404`` instead.
@@ -346,7 +353,7 @@ Released on 28 September, 2015
   document. For example, ``['a.b.c', 'a.b', 'a']`` (Gonéri Le Bouder).
 - Fix: add handling of sub-resource resolving for PUT method (Olivier Poitrey).
 - Fix: ``dependencies`` rule would mistakenly validate documents when target
-  fields happened to also have a ``default`` value. 
+  fields happened to also have a ``default`` value.
 - Fix: According to RFC2617 the separator should be (=) instead of (:). This
   caused at least Chrome not to prompt user for the credentials, and not to
   send the Authorization header even when credentials were in the url (Samuli
@@ -396,7 +403,7 @@ Released on 17 March, 2015.
 Version 0.5.2
 ~~~~~~~~~~~~~
 
-Released on 23 Feb, 2015. 
+Released on 23 Feb, 2015.
 Codename: 'Giulia'.
 
 - Fix: hardening of database concurrency checks. See #561 (Olivier Carrère.)
@@ -480,17 +487,17 @@ Released on 12 Jan, 2015.
 - New: Add extra 4xx response codes for proper handling. Only ``405`` Method
   not allowed, ``406`` Not acceptable, ``409`` Conflict, and ``410`` Gone have
   been added to the list (Kurt Doherty).
-- New: Add serializers for integer and float types (Grisha K.) 
+- New: Add serializers for integer and float types (Grisha K.)
 - New: dev-requirements.txt added to the repo.
 - New: Embedding of documents by references located in any subdocuments. For
   example, query ``embedded={"user.friends":1}`` will return a document with
   "user" and all his "friends" embedded, but only if ``user`` is a subdocument
   and ``friends`` is a list of references (Dmitry Anoshin).
-- New: Allow mongoengine to work properly with cursor counts (Johan Bloemberg) 
+- New: Allow mongoengine to work properly with cursor counts (Johan Bloemberg)
 - New: ``ALLOW_UNKNOWN`` allows unknown fields to be read, not only written as
   before. Closes #397 and #250.
 - New: ``VALIDATION_ERROR_STATUS`` allows setting of the HTTP status code to
-  use for validation errors. Defaults to ``422`` (Olivier Poitrey). 
+  use for validation errors. Defaults to ``422`` (Olivier Poitrey).
 - New: Support for sub-document projections. Fixes #182 (Olivier Poitrey).
 - New: Return ``409 Conflict`` on pymongo ``DuplicateKeyError`` for ``POST``
   requests, as already happens with ``PUT`` requests (Matt Creenan, #537.)
@@ -531,7 +538,7 @@ Released on 12 Jan, 2015.
   #534).
 - Fix: Fix impossible version ranges in setup.py (Marcus Cobden, #531.)
 - Fix: Bug with expanding lists of roles, compromising authorization (Mikael
-  Berg, #527) 
+  Berg, #527)
 - Fix: ``PATCH`` on subdocument fields does not overwrite the whole
   subdocument anymore. Closes #519.
 - Fix: Added support for validation on field attribute with type list (Jorge
@@ -576,7 +583,7 @@ Released on 12 Jan, 2015.
   Magrí).
 - Fix: KeyError when trying to use embedding on a field that is missing from
   document. It was fixed earlier in #319, but came back again after new
-  embedding mechanism (Daniel Lytkin). 
+  embedding mechanism (Daniel Lytkin).
 - Fix: Support for list of strings as default value for fields (hansotronic).
 - Fix: Media fields are now properly returned even in embedded documents.
   Closes #305.
@@ -592,7 +599,7 @@ Released on 12 Jan, 2015.
   them into consideration when validating a query string. Closes #388.
 - Fix: Abort with 400 if unsupported query operators are used. Closes #387.
 - Fix: Return the error if a blacklisted MongoDB operator is used in a query
-  (debug mode). 
+  (debug mode).
 - Fix: Invalid sort syntax raises 500 instead of 400. Addresses #378.
 - Fix: Fix serialization when `type` is missing in schema. #404 (Jaroslav
   Semančík).
@@ -601,7 +608,7 @@ Released on 12 Jan, 2015.
 - Fix: ``test_get_sort_disabled`` occasional failure.
 - Fix: A POST with an empty array leads to a server crash. Now returns a 400
   error isntead and ensure the server won't crash in case of mongo invalid
-  operations (Olivier Poitrey). 
+  operations (Olivier Poitrey).
 - Fix: PATCH and PUT don't respect flask.abort() in a pre-update event. Closes
   #395 (Christopher Larsen).
 - Fix: Validating keyschema rules would cause a TypeError since 0.4. Closes
@@ -634,13 +641,13 @@ Released on 20 June, 2014.
 - [new] ``ALLOWED_WRITE_ROLES``. A list of allowed `roles` for resource
   endpoints with POST, PUT and DELETE methods (Olivier Poitrey).
 - [new] ``ALLOWED_ITEM_READ_ROLES``. A list of allowed `roles` for item
-  endpoints with GET and OPTIONS methods (Olivier Poitrey). 
+  endpoints with GET and OPTIONS methods (Olivier Poitrey).
 - [new] ``ALLOWED_ITEM_WRITE_ROLES``. A list of allowed `roles` for item
-  endpoints with PUT, PATCH and DELETE methods (Olivier Poitrey). 
+  endpoints with PUT, PATCH and DELETE methods (Olivier Poitrey).
 - [new] 'dependencies' validation rule.
 - [new] 'keyschema' validation rule.
 - [new] 'regex' validation rule.
-- [new] 'set' as a core data type. 
+- [new] 'set' as a core data type.
 - [new] 'min' and 'max' now apply to floats and numbers too.
 - [new] File Storage. ``EXTENDED_MEDIA_INFO`` allows a list of meta fields
   (file properties) to forward from the file upload driver (Ben Demaree).
@@ -648,7 +655,7 @@ Released on 20 June, 2014.
 - [new] Support for default values in documents with more than one level of
   data (Javier Gonel).
 - [new] Ability to send entire document in write responses. ``BANDWITH_SAVER``
-  aka Coherence Mode (Josh Villbrandt). 
+  aka Coherence Mode (Josh Villbrandt).
 - [new] ``on_pre_<METHOD>`` events expose the `lookup` dictionary which allows
   for setting up dynamic database lookups on both resource and item endpoints.
 - [new] Return a 400 response on pymongo DuplicateKeyError, with exception
@@ -701,7 +708,7 @@ Released on 20 June, 2014.
   ``auth_field`` value for the current request.
 - [change] ``on_update(ed)`` and ``on_replace(ed)`` callbacks now receive both
   the original document and the updates (Jaroslav Semančík).
-- [change] Review event names (Javier Gonel). 
+- [change] Review event names (Javier Gonel).
 
 - [fix] return 500 instead of 404 if CORS is enabled. Closes #381.
 - [fix] Crash on GET requests on resource endpoints when ID_FIELD is missing on
@@ -729,11 +736,11 @@ Released on 20 June, 2014.
   (Alexander Hendorf).
 - [fix] ``If-Modified-Since`` misbehaviour when a datasource filter is set.
   Closes #258.
-- [fix] Trouble serializing list of dicts. Closes #265 and #244. 
+- [fix] Trouble serializing list of dicts. Closes #265 and #244.
 - [fix] ``HATEOAS`` item links are now coherent actual endpoint URL even when
   natural immutable keys are used in URLs (Junior Vidotti). Closes #256.
 - [fix] Replaced ``ID_FIELD`` by ``item_lookup_field`` on self link.
-  item_lookup_field will default to ``ID_FIELD`` if blank. 
+  item_lookup_field will default to ``ID_FIELD`` if blank.
 
 Version 0.3
 ~~~~~~~~~~~
@@ -838,7 +845,7 @@ Released on 30 November, 2013.
   inject proprietary data into the response stream (Petr Jašek).
 - [new] ``IF_MATCH`` allows to disable checks for ETag matches on edit, replace
   and delete requests. If disabled, requests without an If-Match header will be
-  honored without returning a 403 error. Defaults to True (enabled by default). 
+  honored without returning a 403 error. Defaults to True (enabled by default).
 - [new] ``LINKS`` allows to customize the links field. Default to '_links'.
 - [new] ``ITEMS`` allows to customize the items field. Default to '_items'.
 - [new] ``STATUS`` allows to customize the status field. Default to 'status'.
@@ -847,7 +854,7 @@ Released on 30 November, 2013.
 - [new] A new ``json_encoder`` initialization argument is available. It allows
   to pass custom JSONEncoder or eve.io.BaseJSONEncoder to the Eve instance.
 - [new] A new ``url_converters`` initialization argument is available. It
-  allows to pass custom Flask url converters to the Eve constructor. 
+  allows to pass custom Flask url converters to the Eve constructor.
 - [new] ID_FIELD fields can now be of arbitrary types, not only ObjectIds.
   Thanks to Kelvin Hammond for contributing to this one.  Closes #136.
 - [new] ``pre_<method>`` and ``pre_<method>_<resource>`` event hooks are now
@@ -877,7 +884,7 @@ Released on 30 November, 2013.
 - [change] JSON encoding is now handled at the DataLayer level allowing for
   specialized, granular, data-aware encoding. Also, since the JSON encoder is
   now a class attribute, extensions can replace the pre-defined data layer
-  encoder with their own implementation. Closes #102. 
+  encoder with their own implementation. Closes #102.
 - [fix] HMAC example and docs updated to align with new hmac in Python 2.7.3,
   which is only accepting bytes string. Closes #199.
 - [fix] Properly escape leaf values in XML responses (Florian Rathgeber).

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,9 +1,9 @@
 .. _config:
 
-Configuration 
+Configuration
 =============
 Generally Eve configuration is best done with configuration files. The
-configuration files themselves are actual Python files. 
+configuration files themselves are actual Python files.
 
 Configuration with Files
 ------------------------
@@ -12,7 +12,7 @@ You can choose an alternative filename/path. Just pass it as an argument when
 you instantiate the application.
 
 .. code-block:: python
-    
+
     from eve import Eve
 
     app = Eve(settings='my_settings.py')
@@ -23,12 +23,12 @@ Configuration with a Dictionary
 Alternatively, you can choose to provide a settings dictionary:
 
 .. code-block:: python
-    
+
     my_settings = {
         'MONGO_HOST': 'localhost',
         'MONGO_PORT': 27017,
         'MONGO_DBNAME': 'the_db_name',
-        'DOMAIN': {'contacts': {}} 
+        'DOMAIN': {'contacts': {}}
     }
 
     from eve import Eve
@@ -48,7 +48,7 @@ This is the main reason why you can override or extend the settings with the
 contents of the file the :envvar:`EVE_SETTINGS` environment variable points to.
 The development/local settings could be stored in `settings.py` and then, in
 production, you could export EVE_SETTINGS=/path/to/production_setting.py, and
-you are done. 
+you are done.
 
 There are many alternative ways to handle development/production
 however. Using Python modules for configuration is very convenient, as they
@@ -85,23 +85,23 @@ Global Configuration
 Besides defining the general API behavior, most global configuration settings
 are used to define the standard endpoint ruleset, and can be fine-tuned later,
 when configuring individual endpoints. Global configuration settings are always
-uppercase. 
+uppercase.
 
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
 =================================== =========================================
-``URL_PREFIX``                      URL prefix for all API endpoints. Will be 
+``URL_PREFIX``                      URL prefix for all API endpoints. Will be
                                     used in conjunction with ``API_VERSION`` to
                                     build API endpoints (e.g., ``api`` will be
                                     rendered to ``/api/<endpoint>``).  Defaults
                                     to ``''``.
 
-``API_VERSION``                     API version. Will be used in conjunction with 
+``API_VERSION``                     API version. Will be used in conjunction with
                                     ``URL_PREFIX`` to build API endpoints
                                     (e.g., ``v1`` will be rendered to
                                     ``/v1/<endpoint>``). Defaults to ``''``.
 
-``ALLOWED_FILTERS``                 List of fields on which filtering is allowed. 
+``ALLOWED_FILTERS``                 List of fields on which filtering is allowed.
                                     Can be set to ``[]`` (no filters allowed)
                                     or ``['*']`` (filters allowed on every
                                     field). Unless your API is comprised of
@@ -125,7 +125,7 @@ uppercase.
                                     overridden by resource settings. Defaults
                                     to ``True``.
 
-``PAGINATION``                      ``True`` if pagination is enabled for ``GET`` 
+``PAGINATION``                      ``True`` if pagination is enabled for ``GET``
                                     requests, otherwise ``False``. Can be
                                     overridden by resource settings. Defaults
                                     to ``True``.
@@ -152,10 +152,10 @@ uppercase.
 
 ``QUERY_EMBEDDED``                  Key for the embedding query parameter. Defaults to ``embedded``.
 
-``QUERY_AGGREGATION``               Key for the aggregation query parameter. 
+``QUERY_AGGREGATION``               Key for the aggregation query parameter.
                                     Defaults to ``aggregate``.
 
-``DATE_FORMAT``                     A Python date format used to parse and render 
+``DATE_FORMAT``                     A Python date format used to parse and render
                                     datetime values. When serving requests,
                                     matching JSON strings will be parsed and
                                     stored as ``datetime`` values. In
@@ -163,9 +163,9 @@ uppercase.
                                     rendered as JSON strings using this format.
                                     Defaults to the RFC1123 (ex RFC 822)
                                     standard ``a, %d %b %Y %H:%M:%S GMT``
-                                    ("Tue, 02 Apr 2013 10:29:13 GMT"). 
+                                    ("Tue, 02 Apr 2013 10:29:13 GMT").
 
-``RESOURCE_METHODS``                A list of HTTP methods supported at resource 
+``RESOURCE_METHODS``                A list of HTTP methods supported at resource
                                     endpoints. Allowed values: ``GET``,
                                     ``POST``, ``DELETE``. ``POST`` is used for
                                     insertions. ``DELETE`` will delete *all*
@@ -178,7 +178,7 @@ uppercase.
                                     :ref:`auth` is enabled. Can be overridden
                                     by resource settings. Defaults to ``[]``.
 
-``ITEM_METHODS``                    A list of HTTP methods supported at item 
+``ITEM_METHODS``                    A list of HTTP methods supported at item
                                     endpoints. Allowed values: ``GET``,
                                     ``PATCH``, ``PUT`` and ``DELETE``. ``PATCH``
                                     or, for clients not supporting PATCH,
@@ -186,7 +186,7 @@ uppercase.
                                     header tag, is used for item updates;
                                     ``DELETE`` for item deletion. Can be
                                     overridden by resource settings. Defaults to
-                                    ``['GET']``.  
+                                    ``['GET']``.
 
 ``PUBLIC_ITEM_METHODS``             A list of HTTP methods supported at item
                                     endpoints, left open to public access when
@@ -211,13 +211,13 @@ uppercase.
                                     settings. See :ref:`auth` for more
                                     information. Defaults to ``[]``.
 
-``ALLOWED_ITEM_ROLES``              A list of allowed `roles` for item endpoints. 
+``ALLOWED_ITEM_ROLES``              A list of allowed `roles` for item endpoints.
                                     See :ref:`auth` for more information. Can
                                     be overridden by resource settings.
                                     Defaults to ``[]``.
 
 ``ALLOWED_ITEM_READ_ROLES``         A list of allowed `roles` for item endpoints
-                                    with GET and OPTIONS methods. 
+                                    with GET and OPTIONS methods.
                                     See :ref:`auth` for more information. Can
                                     be overridden by resource settings.
                                     Defaults to ``[]``.
@@ -240,7 +240,7 @@ uppercase.
                                     overridden by resource settings. Defaults
                                     to ``''``.
 
-``CACHE_EXPIRES``                   Value (in seconds) of the ``Expires`` header 
+``CACHE_EXPIRES``                   Value (in seconds) of the ``Expires`` header
                                     field used when serving ``GET`` requests.
                                     If set to a non-zero value, the header will
                                     always be included, regardless of the
@@ -248,20 +248,20 @@ uppercase.
                                     overridden by resource settings. Defaults
                                     to 0.
 
-``X_DOMAINS``                       CORS (Cross-Origin Resource Sharing) support. 
+``X_DOMAINS``                       CORS (Cross-Origin Resource Sharing) support.
                                     Allows API maintainers to specify which
                                     domains are allowed to perform CORS
                                     requests. Allowed values are: ``None``,
                                     a list of domains or ``'*'`` for a wide-open
                                     API. Defaults to ``None``.
 
-``X_HEADERS``                       CORS (Cross-Origin Resource Sharing) support. 
+``X_HEADERS``                       CORS (Cross-Origin Resource Sharing) support.
                                     Allows API maintainers to specify which
                                     headers are allowed to be sent with CORS
                                     requests. Allowed values are: ``None`` or
                                     a list of headers names. Defaults to
                                     ``None``.
-                                
+
 ``X_EXPOSE_HEADERS``                CORS (Cross-Origin Resource Sharing) support.
                                     Allows API maintainers to specify which
                                     headers are exposed within a CORS response.
@@ -276,13 +276,13 @@ uppercase.
                                     will be ignored. Defaults to
                                     ``None``.
 
-``X_MAX_AGE``                       CORS (Cross-Origin Resource Sharing) 
+``X_MAX_AGE``                       CORS (Cross-Origin Resource Sharing)
                                     support. Allows to set max age for the
                                     access control allow header. Defaults to
                                     21600.
 
-                                
-``LAST_UPDATED``                    Name of the field used to record a document's 
+
+``LAST_UPDATED``                    Name of the field used to record a document's
                                     last update date. This field is
                                     automatically handled by Eve. Defaults to
                                     ``_updated``.
@@ -297,7 +297,7 @@ uppercase.
                                     the database. Can be overridden by resource
                                     settings. Defaults to ``_id``.
 
-``ITEM_LOOKUP``                     ``True`` if item endpoints should be generally 
+``ITEM_LOOKUP``                     ``True`` if item endpoints should be generally
                                     available across the API, ``False``
                                     otherwise. Can be overridden by resource
                                     settings. Defaults to ``True``.
@@ -312,7 +312,7 @@ uppercase.
                                     ``regex("[a-f0-9]{24}")`` which is MongoDB
                                     standard ``Object_Id`` format.
 
-``ITEM_TITLE``                      Title to be used when building item references, 
+``ITEM_TITLE``                      Title to be used when building item references,
                                     both in XML and JSON responses. Defaults to
                                     resource name, with the plural 's' stripped
                                     if present. Can and most likely will be
@@ -327,7 +327,7 @@ uppercase.
                                     id of the user who created the resource
                                     item. Can be overridden by resource
                                     settings. Defaults to ``None``, which
-                                    disables the feature. 
+                                    disables the feature.
 
 ``ALLOW_UNKNOWN``                   When ``True``, this option will allow insertion
                                     of arbitrary, unknown fields to any API
@@ -363,7 +363,7 @@ uppercase.
                                     settings. Defaults to ``[]``, effectively
                                     disabling the feature.
 
-``RATE_LIMIT_GET``                  A tuple expressing the rate limit on GET 
+``RATE_LIMIT_GET``                  A tuple expressing the rate limit on GET
                                     requests. The first element of the tuple is
                                     the number of requests allowed, while the
                                     second is the time window in seconds. For
@@ -371,38 +371,38 @@ uppercase.
                                     a limit of 300 requests every 15 minutes.
                                     Defaults to ``None``.
 
-``RATE_LIMIT_POST``                 A tuple expressing the rate limit on POST 
+``RATE_LIMIT_POST``                 A tuple expressing the rate limit on POST
                                     requests. The first element of the tuple is
                                     the number of requests allowed, while the
                                     second is the time window in seconds. For
                                     example ``(300, 60 * 15)`` would set
                                     a limit of 300 requests every 15 minutes.
-                                    Defaults to ``None``. 
+                                    Defaults to ``None``.
 
-``RATE_LIMIT_PATCH``                A tuple expressing the rate limit on PATCH 
+``RATE_LIMIT_PATCH``                A tuple expressing the rate limit on PATCH
                                     requests. The first element of the tuple is
                                     the number of requests allowed, while the
                                     second is the time window in seconds. For
                                     example ``(300, 60 * 15)`` would set
                                     a limit of 300 requests every 15 minutes.
-                                    Defaults to ``None``. 
+                                    Defaults to ``None``.
 
-``RATE_LIMIT_DELETE``               A tuple expressing the rate limit on DELETE 
+``RATE_LIMIT_DELETE``               A tuple expressing the rate limit on DELETE
                                     requests. The first element of the tuple is
                                     the number of requests allowed, while the
                                     second is the time window in seconds. For
                                     example ``(300, 60 * 15)`` would set
                                     a limit of 300 requests every 15 minutes. Defaults to
-                                    ``None``. 
+                                    ``None``.
 
 ``DEBUG``                           ``True`` to enable Debug Mode, ``False``
-                                    otherwise. 
+                                    otherwise.
 
 ``ERROR``                           Allows to customize the error_code field. Defaults
                                     to ``_error``.
 
-``HATEOAS``                         When ``False``, this option disables 
-                                    :ref:`hateoas_feature`. Defaults to ``True``. 
+``HATEOAS``                         When ``False``, this option disables
+                                    :ref:`hateoas_feature`. Defaults to ``True``.
 
 ``ISSUES``                          Allows to customize the issues field. Defaults
                                     to ``_issues``.
@@ -440,11 +440,15 @@ uppercase.
                                     otherwise. Defaults to ``True``. See
                                     :ref:`concurrency`.
 
-``XML``                             ``True`` to enable XML support, ``False`` 
+``ENFORCE_IF_MATCH``                ``True`` to always enforce concurrency control when
+                                    it is enabled, ``False`` otherwise. Defaults to
+                                    ``True``. See :ref:`concurrency`.
+
+``XML``                             ``True`` to enable XML support, ``False``
                                     otherwise. See :ref:`jsonxml`. Defaults to
                                     ``True``.
 
-``JSON``                            ``True`` to enable JSON support, ``False`` 
+``JSON``                            ``True`` to enable JSON support, ``False``
                                     otherwise. See :ref:`jsonxml`. Defaults to
                                     ``True``.
 
@@ -454,8 +458,8 @@ uppercase.
 ``VALIDATION_ERROR_STATUS``         The HTTP status code to use for validation errors.
                                     Defaults to ``422``.
 
-``VERSIONING``                      Enabled documents version control when 
-                                    ``True``. Can be overridden by resource 
+``VERSIONING``                      Enabled documents version control when
+                                    ``True``. Can be overridden by resource
                                     settings. Defaults to ``False``.
 
 ``VERSIONS``                        Suffix added to the name of the primary
@@ -488,7 +492,7 @@ uppercase.
                                     document id will be stored in field
                                     ``_id_document``.
 
-``MONGO_URI``                       A `MongoDB URI`_ which is used in preference 
+``MONGO_URI``                       A `MongoDB URI`_ which is used in preference
                                     of the other configuration variables.
 
 ``MONGO_HOST``                      MongoDB server address. Defaults to ``localhost``.
@@ -503,25 +507,25 @@ uppercase.
 
 ``MONGO_AUTHDBNAME``                MongoDB authorization database name. Defaults to ``None``.
 
-``MONGO_MAX_POOL_SIZE``             The maximum number of idle connections 
+``MONGO_MAX_POOL_SIZE``             The maximum number of idle connections
                                     maintained in the PyMongo connection pool.
                                     Default: PyMongo default.
 
-``MONGO_SOCKET_TIMEOUT_MS``         How long (in milliseconds) a send or 
+``MONGO_SOCKET_TIMEOUT_MS``         How long (in milliseconds) a send or
                                     receive on a socket can take before timing
                                     out. Default: PyMongo default.
 
-``MONGO_CONNECT_TIMEOUT_MS``        How long (in milliseconds) a connection can 
+``MONGO_CONNECT_TIMEOUT_MS``        How long (in milliseconds) a connection can
                                     take to be opened before timing out.
                                     Default: PyMongo default.
 
-``MONGO_REPLICA_SET``               The name of a replica set to connect to; 
+``MONGO_REPLICA_SET``               The name of a replica set to connect to;
                                     this must match the internal name of the
                                     replica set (as deteremined by the
                                     `isMaster <http://www.mongodb.org/display/DOCS/Replica+Set+Commands#ReplicaSetCommands-isMaster>`_
                                     command). Default: ``None``.
 
-``MONGO_READ_PREFERENCE``           Determines how read queries are routed to 
+``MONGO_READ_PREFERENCE``           Determines how read queries are routed to
                                     the replica set members. Must be one of the
                                     constants defined on PyMongo's ReadPreference_,
                                     or the string names thereof.
@@ -529,8 +533,8 @@ uppercase.
 ``MONGO_QUERY_BLACKLIST``           A list of Mongo query operators that are not
                                     allowed to be used in resource filters
                                     (``?where=``). Defaults to ``['$where',
-                                    '$regex']``. 
-                                
+                                    '$regex']``.
+
                                     Mongo JavaScript operators are disabled by
                                     default, as they might be used as vectors
                                     for injection attacks. Javascript queries
@@ -567,24 +571,24 @@ uppercase.
                                     you have other means of getting the binary
                                     (like custom Flask endpoints) but still
                                     want clients to be able to POST/PATCH it.
-                                    Defaults to ``True``. 
+                                    Defaults to ``True``.
 
-``RETURN_MEDIA_AS_URL``             Set it to ``True`` to enable serving media 
+``RETURN_MEDIA_AS_URL``             Set it to ``True`` to enable serving media
                                     files at a dedicated media endpoint.
                                     Defaults to ``False``.
 
-``MEDIA_BASE_URL``                  Base URL to be used when 
-                                    ``RETURN_MEDIA_AS_URL`` is active. Combined 
+``MEDIA_BASE_URL``                  Base URL to be used when
+                                    ``RETURN_MEDIA_AS_URL`` is active. Combined
                                     with ``MEDIA_ENDPOINT`` and ``MEDIA_URL``
                                     dictates the URL returned for media files.
                                     If ``None``, which is the default value,
-                                    the API base address will be used instead. 
+                                    the API base address will be used instead.
 
-``MEDIA_ENDPOINT``                  The media endpoint to be used when 
-                                    ``RETURN_MEDIA_AS_URL`` is enabled. 
+``MEDIA_ENDPOINT``                  The media endpoint to be used when
+                                    ``RETURN_MEDIA_AS_URL`` is enabled.
                                     Defaults to ``media``.
 
-``MEDIA_URL``                       Format of a file url served at the 
+``MEDIA_URL``                       Format of a file url served at the
                                     dedicated media endpoints. Defaults to
                                     ``regex("[a-f0-9]{24}")``.
 
@@ -603,11 +607,11 @@ uppercase.
 ``OPLOG``                           Set it to ``True`` to enable the :ref:`oplog`.
                                     Defaults to ``False``.
 
-``OPLOG_NAME``                      This is the name of the database collection 
+``OPLOG_NAME``                      This is the name of the database collection
                                     where the :ref:`oplog` is stored. Defaults
                                     to ``oplog``.
 
-``OPLOG_METHODS``                   List of HTTP methods which operations 
+``OPLOG_METHODS``                   List of HTTP methods which operations
                                     should be logged in the :ref:`oplog`.
                                     Defaults to ``['DELETE', 'POST', 'PATCH',
                                     'PUT']``.
@@ -616,18 +620,18 @@ uppercase.
                                     will include changes into the :ref:`oplog` entry.
                                     Defaults to ``['DELETE','PATCH', 'PUT']``.
 
-``OPLOG_ENDPOINT``                  Name of the :ref:`oplog` endpoint. If the 
+``OPLOG_ENDPOINT``                  Name of the :ref:`oplog` endpoint. If the
                                     endpoint is enabled it can be configured
                                     like any other API endpoint. Set it to
                                     ``None`` to disable the endpoint. Defaults
-                                    to ``None``. 
+                                    to ``None``.
 
-``OPLOG_AUDIT``                     Set it to ``True`` to enable the audit 
+``OPLOG_AUDIT``                     Set it to ``True`` to enable the audit
                                     feature. When audit is enabled client IP
                                     and document changes are also logged to the
                                     :ref:`oplog`. Defaults to ``True``.
 
-``OPLOG_RETURN_EXTRA_FIELD``        When enabled, the optional ``extra`` field 
+``OPLOG_RETURN_EXTRA_FIELD``        When enabled, the optional ``extra`` field
                                     will be included in the payload returned by
                                     the ``OPLOG_ENDPOINT``. Defaults to
                                     ``False``.
@@ -635,7 +639,7 @@ uppercase.
 ``SCHEMA_ENDPOINT``                 Name of the :ref:`schema_endpoint`. Defaults
                                     to ``None``.
 
-``HEADER_TOTAL_COUNT``              Custom header containing total count of 
+``HEADER_TOTAL_COUNT``              Custom header containing total count of
                                     items in response payloads for collection
                                     ``GET`` requests. This is handy for ``HEAD``
                                     requests when client wants to know items
@@ -682,13 +686,13 @@ uppercase.
 ``VALIDATION_ERROR_AS_STRING``      If ``True`` even single field errors will
                                     be returned in a list. By default single
                                     field errors are returned as strings while
-                                    multiple field errors are bundled in a 
+                                    multiple field errors are bundled in a
                                     list. If you want to standardize the field
                                     errors output, set this setting to ``True``
                                     and you will always get a list of field
                                     issues. Defaults to ``False``.
 
-``UPSERT_ON_PUT``                   ``PUT`` attempts to create a document if it 
+``UPSERT_ON_PUT``                   ``PUT`` attempts to create a document if it
                                     does not exist. The URL endpoint will be
                                     used as ``ID_FIELD`` value (if ``ID_FIELD``
                                     is included with the payload, it will be
@@ -736,7 +740,7 @@ always lowercase.
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
 =============================== ===============================================
-``url``                         The endpoint URL. If omitted the resource key 
+``url``                         The endpoint URL. If omitted the resource key
                                 of the ``DOMAIN`` dict will be used to build
                                 the URL. As an example, ``contacts`` would make
                                 the `people` resource available at
@@ -752,7 +756,7 @@ always lowercase.
                                 subresource-like endpoints. See
                                 :ref:`subresources`.
 
-``allowed_filters``             List of fields on which filtering is allowed. 
+``allowed_filters``             List of fields on which filtering is allowed.
                                 Can be set to ``[]`` (no filters allowed), or
                                 ``['*']`` (fields allowed on every field).
                                 Defaults to ``['*']``.
@@ -763,13 +767,13 @@ always lowercase.
                                 then whitelisting valid ones at the local level
                                 is the way to go.
 
-``sorting``                     ``True`` if sorting is enabled, ``False`` 
+``sorting``                     ``True`` if sorting is enabled, ``False``
                                 otherwise. Locally overrides ``SORTING``.
-                                
+
 ``pagination``                  ``True`` if pagination is enabled, ``False``
                                 otherwise. Locally overrides ``PAGINATION``.
 
-``resource_methods``            A list of HTTP methods supported at resource 
+``resource_methods``            A list of HTTP methods supported at resource
                                 endpoint. Allowed values: ``GET``, ``POST``,
                                 ``DELETE``. Locally overrides
                                 ``RESOURCE_METHODS``.
@@ -783,7 +787,7 @@ always lowercase.
                                 :ref:`auth` is enabled. Locally overrides
                                 ``PUBLIC_METHODS``.
 
-``item_methods``                A list of HTTP methods supported at item 
+``item_methods``                A list of HTTP methods supported at item
                                 endpoint. Allowed values: ``GET``, ``PATCH``,
                                 ``PUT`` and ``DELETE``. ``PATCH`` or, for
                                 clients not supporting PATCH, ``POST`` with
@@ -823,19 +827,19 @@ always lowercase.
                                 See :ref:`auth` for more information.
                                 Locally overrides ``ALLOWED_ITEM_WRITE_ROLES``.
 
-``allowed_item_roles``          A list of allowed `roles` for item endpoint. 
+``allowed_item_roles``          A list of allowed `roles` for item endpoint.
                                 See :ref:`auth` for more information.
                                 Locally overrides ``ALLOWED_ITEM_ROLES``.
 
-``cache_control``               Value of the ``Cache-Control`` header field 
+``cache_control``               Value of the ``Cache-Control`` header field
                                 used when serving ``GET`` requests. Leave empty
                                 if you don't want to include cache directives
                                 with API responses. Locally overrides
                                 ``CACHE_CONTROL``.
 
-``cache_expires``               Value (in seconds) of the ``Expires`` header 
+``cache_expires``               Value (in seconds) of the ``Expires`` header
                                 field used when serving ``GET`` requests. If
-                                set to a non-zero value, the header will 
+                                set to a non-zero value, the header will
                                 always be included, regardless of the setting
                                 of ``CACHE_CONTROL``. Locally overrides
                                 ``CACHE_EXPIRES``.
@@ -844,7 +848,7 @@ always lowercase.
                                 within the database. Locally overrides
                                 ``ID_FIELD``.
 
-``item_lookup``                 ``True`` if item endpoint should be available, 
+``item_lookup``                 ``True`` if item endpoint should be available,
                                 ``False`` otherwise. Locally overrides
                                 ``ITEM_LOOKUP``.
 
@@ -857,7 +861,7 @@ always lowercase.
 ``resource_title``              Title used when building resource links
                                 (HATEOAS). Defaults to resource's ``url``.
 
-``item_title``                  Title to be used when building item references, 
+``item_title``                  Title to be used when building item references,
                                 both in XML and JSON responses. Overrides
                                 ``ITEM_TITLE``.
 
@@ -876,9 +880,9 @@ always lowercase.
                                 snippet below for an usage example of this
                                 feature.
 
-``datasource``                  Explicitly links API resources to database 
+``datasource``                  Explicitly links API resources to database
                                 collections. See `Advanced Datasource
-                                Patterns`_. 
+                                Patterns`_.
 
 ``auth_field``                  Enables :ref:`user-restricted`. When the
                                 feature is enabled, users can only
@@ -886,7 +890,7 @@ always lowercase.
                                 themselves. The keyword contains the actual
                                 name of the field used to store the id of
                                 the user who created the resource item. Locally
-                                overrides ``AUTH_FIELD``. 
+                                overrides ``AUTH_FIELD``.
 
 ``allow_unknown``               When ``True``, this option will allow insertion
                                 of arbitrary, unknown fields to the endpoint.
@@ -911,11 +915,11 @@ always lowercase.
                                 automatically handled fields (``ID_FIELD``,
                                 ``LAST_UPDATED``, ``DATE_CREATED``, ``ETAG``)
                                 are included in response payloads. Overrides
-                                ``EXTRA_RESPONSE_FIELDS``. 
+                                ``EXTRA_RESPONSE_FIELDS``.
 
 ``hateoas``                     When ``False``, this option disables
                                 :ref:`hateoas_feature` for the resource.
-                                Defaults to ``True``. 
+                                Defaults to ``True``.
 
 ``mongo_write_concern``         A dictionary defining MongoDB write concern
                                 settings for the endpoint datasource. All
@@ -930,22 +934,22 @@ always lowercase.
                                 will still happen; Mongo will just be unable
                                 to check that it's being written to multiple
                                 servers.)
-                                
+
 ``mongo_prefix``                Allows overriding of the default ``MONGO``
                                 prefix, which is used when retrieving MongoDB
                                 settings from configuration.
-                                
+
                                 For example if ``mongo_prefix`` is set to
                                 ``MONGO2`` then, when serving requests for the
                                 endpoint, ``MONGO2`` prefixed settings will
                                 be used to access the database.
 
-                                This allows for eventually serving data from 
+                                This allows for eventually serving data from
                                 a different database/server at every endpoint.
 
                                 See also: :ref:`authdrivendb`.
 
-``mongo_indexes``               Allows to specify a set of indexes to be 
+``mongo_indexes``               Allows to specify a set of indexes to be
                                 created for this resource before the app is
                                 launched.
 
@@ -955,7 +959,7 @@ always lowercase.
                                 a tuple with a list of field/direction pairs
                                 *and* index options expressed as a dict, such
                                 as ``{'index name': [('field', 1)], 'index with
-                                args': ([('field', 1)], {"sparse": True})}``. 
+                                args': ([('field', 1)], {"sparse": True})}``.
 
                                 Multiple pairs are used to create compound
                                 indexes. Direction takes all kind of values
@@ -975,13 +979,13 @@ always lowercase.
                                 for which the definition has been changed, will
                                 be dropped and re-created.
 
-``authentication``              A class with the authorization logic for the 
+``authentication``              A class with the authorization logic for the
                                 endpoint. If not provided the eventual
                                 general purpose auth class (passed as
-                                application constructor argument) will be used. 
-                                For details on authentication and authorization 
+                                application constructor argument) will be used.
+                                For details on authentication and authorization
                                 see :ref:`auth`.  Defaults to ``None``,
-                                
+
 ``embedded_fields``             A list of fields for which :ref:`embedded_docs`
                                 is enabled by default. For this feature to work
                                 properly fields in the list must be
@@ -997,7 +1001,7 @@ always lowercase.
                                 queries (``?where=``) and parsing of payloads.
                                 Defaults to ``False``.
 
-``internal_resource``           When ``True``, this option makes the resource 
+``internal_resource``           When ``True``, this option makes the resource
                                 internal. No HTTP action can be performed on
                                 the endpoint, which is still accessible from
                                 the Eve data layer. See
@@ -1009,7 +1013,7 @@ always lowercase.
                                 Defaults to ``None`` which means that by
                                 default all fields are included in the computation.
                                 It looks like ``['field1', 'field2',
-                                'field3.nested_field', ...]``.  
+                                'field3.nested_field', ...]``.
 
 ``schema``                      A dict defining the actual data structure being
                                 handled by the resource. Enables data
@@ -1037,7 +1041,7 @@ API settings:
 
         # by default, the standard item entry point is defined as
         # '/people/<ObjectId>/'. We leave it untouched, and we also enable an
-        # additional read-only entry point. This way consumers can also perform 
+        # additional read-only entry point. This way consumers can also perform
         # GET requests at '/people/<lastname>'.
         'additional_lookup': {
             'url': 'regex("[\w]+")',
@@ -1140,18 +1144,18 @@ defining the field validation rules. Allowed validation rules are:
 ``min``, ``max``                Minimum and maximum values allowed for
                                 ``integer``, ``float`` and ``number`` types.
 
-``allowed``                     List of allowed values for ``string`` and 
+``allowed``                     List of allowed values for ``string`` and
                                 ``list`` types.
 
 ``empty``                       Only applies to string fields. If ``False``,
-                                validation will fail if the value is empty. 
+                                validation will fail if the value is empty.
                                 Defaults to ``True``.
 
-``items``                       Defines a list of values allowed in a ``list`` 
+``items``                       Defines a list of values allowed in a ``list``
                                 of fixed length, see `docs <http://docs.python-cerberus.org/en/latest/usage.html#items-list>`_.
 
-``schema``                      Validation schema for ``dict`` types and 
-                                arbitrary length ``list`` types. For details 
+``schema``                      Validation schema for ``dict`` types and
+                                arbitrary length ``list`` types. For details
                                 and usage examples, see `Cerberus documentation <http://docs.python-cerberus.org/en/latest/usage.html#schema-dict>`_.
 
 ``unique``                      The value of the field must be unique within
@@ -1165,14 +1169,14 @@ defining the field validation rules. Allowed validation rules are:
                                 documents carry the same value for a field
                                 where the 'unique' constraint is set, the
                                 payload will validate successfully, as there
-                                are no duplicates in the database (yet). 
-                                
+                                are no duplicates in the database (yet).
+
                                 If this is an issue, the client can always send
                                 the documents one at a time for insertion, or
                                 validate locally before submitting the payload
                                 to the API.
 
-``unique_to_user``              The field value is unique to the user. This is 
+``unique_to_user``              The field value is unique to the user. This is
                                 useful when :ref:`user-restricted` is
                                 enabled on an endpoint. The rule will be
                                 validated against *user data only*. So in this
@@ -1189,15 +1193,15 @@ defining the field validation rules. Allowed validation rules are:
 
                                 - ``resource``: the name of the resource being referenced;
                                 - ``field``: the field name in the foreign resource;
-                                - ``embeddable``: set to ``True`` if clients can 
-                                  request the referenced document to be embedded 
+                                - ``embeddable``: set to ``True`` if clients can
+                                  request the referenced document to be embedded
                                   with the serialization. See :ref:`embedded_docs`. Defaults to ``False``.
-                                - ``version``: set to ``True`` to require a 
-                                  ``_version`` with the data relation. See :ref:`document_versioning`. 
+                                - ``version``: set to ``True`` to require a
+                                  ``_version`` with the data relation. See :ref:`document_versioning`.
                                   Defaults to ``False``.
 
-``nullable``                    If ``True``, the field value can be set to 
-                                ``None``. 
+``nullable``                    If ``True``, the field value can be set to
+                                ``None``.
 
 ``default``                     The default value for the field. When serving
                                 POST and PUT requests, missing fields will be
@@ -1242,7 +1246,7 @@ defining the field validation rules. Allowed validation rules are:
                                       }
                                     }
 
-``versioning``                  Enabled documents version control when ``True``. 
+``versioning``                  Enabled documents version control when ``True``.
                                 Defaults to ``False``.
 
 ``versioned``                   If ``True``, this field will be included in the
@@ -1254,37 +1258,37 @@ defining the field validation rules. Allowed validation rules are:
                                 for all of which must validate with given
                                 schema. See `valueschema example <http://docs.python-cerberus.org/en/latest/usage.html#valueschema>`_.
 
-``propertyschema``              This is the counterpart to ``valueschema`` that 
+``propertyschema``              This is the counterpart to ``valueschema`` that
                                 validates the keys of a dict.   Validation
                                 schema for all values of a ``dict``. See
                                 `propertyschema example
                                 <http://docs.python-cerberus.org/en/latest/usage.html#propertyschema>`_.
 
 
-``regex``                       Validation will fail if field value does not 
-                                match the provided regex rule. Only applies to 
+``regex``                       Validation will fail if field value does not
+                                match the provided regex rule. Only applies to
                                 string fields. See `email validation example <http://docs.python-cerberus.org/en/latest/usage.html#regex>`_
 
 
-``dependencies``                This rule allows a list of fields that must be 
-                                present in order for the target field to be 
+``dependencies``                This rule allows a list of fields that must be
+                                present in order for the target field to be
                                 allowed. See `dependencies example <http://docs.python-cerberus.org/en/latest/usage.html#dependencies>`_
 
-``anyof``                       This rule allows you to list multiple sets of 
+``anyof``                       This rule allows you to list multiple sets of
                                 rules to validate against. The field will be
                                 considered valid if it validates against one
                                 set in the list. See `anyof example <http://docs.python-cerberus.org/en/latest/usage.html#anyof>`_
 
-``allof``                       Same as ``anyof``, except that all rule 
+``allof``                       Same as ``anyof``, except that all rule
                                 collections in the list must validate.
 
-``noneof``                      Same as ``anyof``, except that it requires no 
-                                rule collections in the list to validate. 
+``noneof``                      Same as ``anyof``, except that it requires no
+                                rule collections in the list to validate.
 
-``oneof``                       Same as ``anyof``, except that only one rule 
+``oneof``                       Same as ``anyof``, except that only one rule
                                 collections in the list can validate.
 
-``coerce``                      Type coercion allows you to apply a callable to 
+``coerce``                      Type coercion allows you to apply a callable to
                                 a value before any other validators run. The
                                 return value of the callable replaces the new
                                 value in the document. This can be used to
@@ -1315,17 +1319,17 @@ Advanced Datasource Patterns
 ----------------------------
 The ``datasource`` keyword allows to explicitly link API resources to database
 collections. If omitted, the domain resource key is assumed to also be the name
-of the database collection. It is a dictionary with four allowed keys: 
+of the database collection. It is a dictionary with four allowed keys:
 
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
 =============================== ==============================================
-``source``                      Name of the database collection consumed by the 
+``source``                      Name of the database collection consumed by the
                                 resource.  If omitted, the resource name is
                                 assumed to also be a valid collection name. See
                                 :ref:`source`.
 
-``filter``                      Database query used to retrieve and validate 
+``filter``                      Database query used to retrieve and validate
                                 data. If omitted, by default the whole
                                 collection is retrievied. See :ref:`filter`.
 
@@ -1353,23 +1357,23 @@ of the database collection. It is a dictionary with four allowed keys:
                                 This is a dictionary with one or more of the
                                 following keys:
 
-                                - ``pipeline``. The aggregation pipeline. 
+                                - ``pipeline``. The aggregation pipeline.
                                   Syntax must match the one supported by
                                   PyMongo. For more informations see `PyMongo
                                   Aggregation Examples`_ and the official
                                   `MongoDB Aggregation Framework`_
-                                  documentation. 
+                                  documentation.
 
                                 - ``options``. Aggregation options. Must be
-                                  a dictionary with one or more of these keys: 
-                                
+                                  a dictionary with one or more of these keys:
+
                                     - ``allowDiskUse`` (bool)
                                     - ``maxTimeMS`` (int)
                                     - ``batchSize`` (int)
                                     - ``useCursor`` (bool)
 
                                 You only need to set ``options`` if you want to
-                                change any of `PyMongo aggregation defaults`_. 
+                                change any of `PyMongo aggregation defaults`_.
 
 =============================== ==============================================
 
@@ -1386,7 +1390,7 @@ Database filters for the API endpoint are set with the ``filter`` keyword.
             'filter': {'username': {'$exists': True}}
             }
         }
-  
+
 In the example above, the API endpoint for the `people` resource will only
 expose and update documents with an existing `username` field.
 
@@ -1416,7 +1420,7 @@ the same `people` collection on the database.
 
     people = {
         'datasource': {
-            'source': 'people', 
+            'source': 'people',
             'filter': {'userlevel': 1}
             }
         }
@@ -1441,7 +1445,7 @@ resource keyword allows you to redefine the fieldset.
         }
 
 The above setting will expose only the `username` field to GET requests, no
-matter the schema_ defined for the resource. 
+matter the schema_ defined for the resource.
 
 Likewise, you can exclude fields from API responses:
 
@@ -1453,7 +1457,7 @@ Likewise, you can exclude fields from API responses:
             }
         }
 
-The above will include all document fields but `username`. 
+The above will include all document fields but `username`.
 
 Please note that POST and PATCH methods will still allow the whole schema to be
 manipulated. This feature can come in handy when, for example, you want to
@@ -1462,7 +1466,7 @@ read access open to the public.
 
 .. admonition:: See also
 
-    - :ref:`projections` 
+    - :ref:`projections`
     - :ref:`projection_filestorage`
 
 .. _Cerberus: http://python-cerberus.org

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -312,7 +312,7 @@ Would return documents sorted by lastname in descending order.
 Sorting is enabled by default and can be disabled both globally and/or at
 resource level (see ``SORTING`` in :ref:`global` and ``sorting`` in
 :ref:`domain`). It is also possible to set the default sort at every API
-endpoints (see ``default_sort`` in :ref:`domain`). 
+endpoints (see ``default_sort`` in :ref:`domain`).
 
 .. admonition:: Please note
 
@@ -387,14 +387,14 @@ is at ``examples.com/api/v1``, the ``self`` link in the above example would
 mean that the *people* endpoint is located at ``examples.com/api/v1/people``.
 
 Please note that ``next``, ``previous`` and ``last`` items will only be
-included when appropriate. 
+included when appropriate.
 
 Disabling HATEOAS
 ~~~~~~~~~~~~~~~~~
 HATEOAS can be disabled both at the API and/or resource level. Why would you
 want to turn HATEOAS off? Well, if you know that your client application is not
 going to use the feature, then you might want to save on both bandwidth and
-performance. 
+performance.
 
 .. _jsonxml:
 
@@ -434,14 +434,14 @@ conditional requests by using the ``If-Modified-Since`` header:
 
 .. code-block:: console
 
-    $ curl -H "If-Modified-Since: Wed, 05 Dec 2012 09:53:07 GMT" -i http://eve-demo.herokuapp.com/people/521d6840c437dc0002d1203c 
+    $ curl -H "If-Modified-Since: Wed, 05 Dec 2012 09:53:07 GMT" -i http://eve-demo.herokuapp.com/people/521d6840c437dc0002d1203c
     HTTP/1.1 200 OK
 
 or the ``If-None-Match`` header:
 
 .. code-block:: console
 
-    $ curl -H "If-None-Match: 1234567890123456789012345678901234567890" -i http://eve-demo.herokuapp.com/people/521d6840c437dc0002d1203c 
+    $ curl -H "If-None-Match: 1234567890123456789012345678901234567890" -i http://eve-demo.herokuapp.com/people/521d6840c437dc0002d1203c
     HTTP/1.1 200 OK
 
 
@@ -504,9 +504,13 @@ Disabling concurrency control
 If your use case requires, you can opt to completely disable concurrency
 control. ETag match checks can be disabled by setting the ``IF_MATCH``
 configuration variable to ``False`` (see :ref:`global`). When concurrency
-control is disabled no etag is provided with responses. You should be careful
+control is disabled no ETag is provided with responses. You should be careful
 about disabling this feature, as you would effectively open your API to the
-risk of older versions replacing your documents.
+risk of older versions replacing your documents. Alternatively, ETag match
+checks can be made optional by the client if ``ENFORCE_IF_MATCH`` is disabled.
+When concurrenncy check enforcement is disabled, requests with the ``If-Match``
+header will be processed as conditional requests, and requests made without
+the ``If-Match`` header will not be processed as conditional.
 
 .. _bulk_insert:
 
@@ -602,7 +606,7 @@ request:
     ]
 
 In the example above, the first document did not validate so the whole request
-has been rejected. 
+has been rejected.
 
 When all documents pass validation and are inserted correctly the response
 status is ``201 Created``. If any document fails validation the response status
@@ -731,7 +735,7 @@ In general you don't really want to add JSONP when you can enable CORS instead:
     browsers now support CORS making it a viable cross-browser alternative (source_.)
 
 There are circumstances however when you do need JSONP, like when you have to
-support legacy software (IE6 anyone?) 
+support legacy software (IE6 anyone?)
 
 To enable JSONP in Eve you just set
 ``JSONP_ARGUMENT``. Then, any valid request with ``JSONP_ARGUMENT`` will get
@@ -744,7 +748,7 @@ back a response wrapped with said argument value. For example if you set
     hello(<JSON here>)
 
 Requests with no ``callback`` argument will be served with no JSONP.
- 
+
 
 Read-only by default
 --------------------
@@ -1031,7 +1035,7 @@ Pre-Request Event Hooks
 ~~~~~~~~~~~~~~~~~~~~~~~
 When a GET/HEAD, POST, PATCH, PUT, DELETE request is received, both
 a ``on_pre_<method>`` and a ``on_pre_<method>_<resource>`` event is raised.
-You can subscribe to these events with multiple callback functions. 
+You can subscribe to these events with multiple callback functions.
 
 .. code-block:: pycon
 
@@ -1051,13 +1055,13 @@ You can subscribe to these events with multiple callback functions.
 Callbacks will receive the resource being requested, the original
 ``flask.request`` object and the current lookup dictionary as arguments (only
 exception being the ``on_pre_POST`` hook which does not provide a ``lookup``
-argument). 
+argument).
 
 Dynamic Lookup Filters
 ^^^^^^^^^^^^^^^^^^^^^^
 Since the ``lookup`` dictionary will be used by the data layer to retrieve
 resource documents, developers may choose to alter it in order to add custom
-logic to the lookup query. 
+logic to the lookup query.
 
 .. code-block:: python
 
@@ -1074,7 +1078,7 @@ Altering the lookup dictionary at runtime would have similar effects to
 applying :ref:`filter` via configuration. However, you can only set static
 filters via configuration whereas by hooking to the ``on_pre_<METHOD>`` events
 you are allowed to set dynamic filters instead, which allows for additional
-flexibility. 
+flexibility.
 
 Post-Request Event Hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1346,7 +1350,7 @@ the item in the database that is about to be updated. Callback functions
 could hook into these events to arbitrarily add or update fields in
 `updates`, or to perform other accessory action.
 
-`After` the item has been updated: 
+`After` the item has been updated:
 
 - ``on_updated`` is fired for any resource endpoint.
 - ``on_updated_<resource_name>`` is fired only when the `<resource_name>`
@@ -1484,13 +1488,13 @@ When a document is requested media files will be returned as Base64 strings,
             }
         ]
         ...
-   } 
+   }
 
 However, if the ``EXTENDED_MEDIA_INFO`` list is populated (it isn't by
 default) the payload format will be different. This flag allows passthrough
 from the driver of additional meta fields. For example, using the MongoDB
 driver, fields like ``content_type``, ``name`` and ``length`` can be added to
-this list and will be passed-through from the underlying driver. 
+this list and will be passed-through from the underlying driver.
 
 When ``EXTENDED_MEDIA_INFO`` is used the field will be a dictionary
 whereas the file itself is stored under the ``file`` key and other keys
@@ -1519,7 +1523,7 @@ Then the output will be something like
         ...
     }
 
-For MongoDB, further fields can be found in the `driver documentation`_. 
+For MongoDB, further fields can be found in the `driver documentation`_.
 
 If you have other means to retrieve the media files (custom Flask endpoint for
 example) then the media files can be excluded from the payload by setting to
@@ -1532,7 +1536,7 @@ While returning files embedded as Base64 fields is the default behaviour, you
 can opt for serving them at a dedicated media endpoint. You achieve that by
 setting ``RETURN_MEDIA_AS_URL`` to ``True``. When this feature is enabled
 document fields contain urls to the correspondent files, which are served at the
-media endpoint. 
+media endpoint.
 
 You can change the default media endpoint (``media``) by updating the
 ``MEDIA_BASE_URL`` and ``MEDIA_ENDPOINT`` setting. Suppose you are storing your
@@ -1602,19 +1606,19 @@ response payloads by sending requests like this one:
     - :ref:`datasource`
 
     for details on the ``datasource`` setting.
-    
+
 .. _multipart:
 
 Note on media files as ``multipart/data-form``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you are uploading media files as ``multipart/data-form`` all the
-additional fields except the file fields will be treated as ``strings`` 
+additional fields except the file fields will be treated as ``strings``
 for all field validation purposes.  If you have already defined some of
 the resource fields to be of different type (boolean, number, list etc)
 the validation rules for these fields would fail, preventing you to
 succesffully submit your resource.
 
-If you still want to be able to perform field validation in this case, you 
+If you still want to be able to perform field validation in this case, you
 will have to turn on ``MULTIPART_FORM_FIELDS_AS_JSON`` in your settings
 file in order to treat the incoming fields as JSON encoded strings and still
 be able to validate your fields.
@@ -1622,7 +1626,7 @@ be able to validate your fields.
 Please note, that in case you indeed turn on ``MULTIPART_FORM_FIELDS_AS_JSON``
 you will have to submit all resource fields as properly encoded JSON strings.
 
-For example a ``number`` should be submited as ``1234`` (as you would normally 
+For example a ``number`` should be submited as ``1234`` (as you would normally
 expect). A ``boolean`` will have to be send as ``true`` (note the lowercase
 ``t``). A ``list`` of strings as ``["abc", "xyz"]``. And finally
 a ``string``, which is the thing that will most likely trip, you will have
@@ -1645,7 +1649,7 @@ encoded in GeoJSON_ format. All GeoJSON objects supported by MongoDB_ are availa
     - ``Polygon``
     - ``MultiPolygon``
     - ``GeometryCollection``
-      
+
 These are implemented as native Eve data types (see :ref:`schema`) so they are
 are subject to proper validation.
 
@@ -1661,7 +1665,7 @@ a ``location`` field is of type Point_.
         },
         ...
     }
-    
+
 Storing a contact along with its location is pretty straightforward:
 
 .. code-block:: console
@@ -1675,13 +1679,13 @@ As a general rule all MongoDB `geospatial query operators`_ and their associated
 geometry specifiers are supported. In this example we are using the `$near`_
 operator to query for all contacts living in a location within 1000 meters from
 a certain point:
-    
+
 ::
 
     ?where={"location": {"$near": {"$geometry": {"type":"Point", "coordinates": [10.0, 20.0]}, "$maxDistance": 1000}}}
 
 Please refer to MongoDB documentation for details on geo queries.
-	
+
 .. _internal_resources:
 
 Internal Resources
@@ -1720,7 +1724,7 @@ Something like this:
 
 .. code-block:: python
    :emphasize-lines: 12
-    
+
     from eve import Eve
 
     def on_generic_inserted(self, resource, documents):
@@ -1756,7 +1760,7 @@ attributes:
 ``clientip``                        IP address of the client performing the
                                     request.
 
-``url``                             Full request URL, eventual query parameters 
+``url``                             Full request URL, eventual query parameters
                                     included.
 
 ``method``                          Request method (``POST``, ``GET``, etc.)
@@ -1788,7 +1792,7 @@ time a custom function is invoked.
         # enable logging to 'app.log' file
         handler = logging.FileHandler('app.log')
 
-        # set a custom log format, and add request 
+        # set a custom log format, and add request
         # metadata to each log line
         handler.setFormatter(logging.Formatter(
             '%(asctime)s %(levelname)s: %(message)s '
@@ -1796,7 +1800,7 @@ time a custom function is invoked.
             'url: %(url)s, method:%(method)s'))
 
         # the default log level is set to WARNING, so
-        # we have to explictly set the logging level 
+        # we have to explictly set the logging level
         # to INFO to get our custom message logged.
         app.logger.setLevel(logging.INFO)
 
@@ -1809,7 +1813,7 @@ time a custom function is invoked.
 
 Currently only exceptions raised by the MongoDB layer and ``POST``, ``PATCH``
 and ``PUT`` methods are logged. The idea is to also add some ``INFO`` and
-possibly ``DEBUG`` level events in the future. 
+possibly ``DEBUG`` level events in the future.
 
 .. _oplog:
 
@@ -1841,36 +1845,36 @@ If ``OPLOG_AUDIT`` is enabled entries also expose:
 
 - client IP
 - Username or token, if available
-- changes applied to the document (for ``DELETE`` the whole document is included). 
+- changes applied to the document (for ``DELETE`` the whole document is included).
 
 A typical oplog entry looks like this:
 
 .. code-block:: python
 
     {
-        "o": "DELETE", 
-        "r": "people", 
+        "o": "DELETE",
+        "r": "people",
         "i": "542d118938345b614ea75b3c",
         "c": {...},
         "ip": "127.0.0.1",
         "u": "admin",
-        "_updated": "Fri, 03 Oct 2014 08:16:52 GMT", 
+        "_updated": "Fri, 03 Oct 2014 08:16:52 GMT",
         "_created": "Fri, 03 Oct 2014 08:16:52 GMT",
         "_etag": "e17218fbca41cb0ee6a5a5933fb9ee4f4ca7e5d6"
-        "_id": "542e5b7438345b6dadf95ba5", 
+        "_id": "542e5b7438345b6dadf95ba5",
         "_links": {...},
     }
 
-To save a little space (at least on MongoDB) field names have been shortened: 
+To save a little space (at least on MongoDB) field names have been shortened:
 
 - ``o`` stands for operation performed
 - ``r`` stands for resource endpoint
 - ``i`` stands for document id
 - ``ip`` is the client IP
-- ``u`` stands for user (or token) 
-- ``c`` stands for changes occurred 
+- ``u`` stands for user (or token)
+- ``c`` stands for changes occurred
 - ``extra`` is an optional field which you can use to store custom data
-  
+
 ``_created`` and ``_updated`` are relative to the target document, which comes
 handy in a variety of scenarios (like when the oplog is available to clients,
 more on this later).
@@ -1896,14 +1900,14 @@ Six settings are dedicated to the OpLog:
 As you can see the oplog feature is turned off by default. Also, since
 ``OPLOG_ENDPOINT`` defaults to ``None``, even if you switch the feature on no
 public oplog endpoint will be available. You will have to explictly set the
-endpoint name in order to expose your oplog to the public. 
+endpoint name in order to expose your oplog to the public.
 
 The Oplog endpoint
 ~~~~~~~~~~~~~~~~~~
 Since the oplog endpoint is nothing but a standard API endpoint, you can
 customize it. This allows for setting up custom authentication (you might want
 this resource to be only accessible for administrative purposes) or any other
-useful setting. 
+useful setting.
 
 Note that while you can change most of its settings, the endpoint will always
 be read-only so setting either ``resource_methods`` or ``item_methods`` to
@@ -1926,7 +1930,7 @@ Every time the oplog is about to be updated the ``on_oplog_push`` event is fired
 You can hook one or more callback functions to this event. Callbacks receive
 ``resource`` and ``entries`` as arguments. The former is the resource name
 while the latter is a list of oplog entries which are about to be written to
-disk. 
+disk.
 
 Your callback can add an optional ``extra`` field to canonical oplog entries.
 The field can be of any type. In this example we are adding a custom dict to
@@ -1946,7 +1950,7 @@ each entry:
 Please note that unless you explictly set ``OPLOG_RETURN_EXTRA_FIELD`` to
 ``True``, the ``extra`` field will *not* be returned by the ``OPLOG_ENDPOINT``.
 
-.. note:: 
+.. note::
 
     Are you on MongoDB? Consider making the oplog a `capped collection`_. Also,
     in case you are wondering yes, the Eve oplog is blatantly inpsired by the
@@ -1985,8 +1989,8 @@ collections ``OrderedDict`` where explicit ordering is required eg ``$sort``:
         'datasource': {
             'aggregation': {
                 'pipeline': [
-                    {"$unwind": "$tags"}, 
-                    {"$group": {"_id": "$tags", "count": {"$sum": 1}}}, 
+                    {"$unwind": "$tags"},
+                    {"$group": {"_id": "$tags", "count": {"$sum": 1}}},
                     {"$sort": SON([("count", -1), ("_id", -1)])}
                 ]
             }
@@ -2003,8 +2007,8 @@ Let's update the pipeline a little bit:
         'datasource': {
             'aggregation': {
                 'pipeline': [
-                    {"$unwind": "$tags"}, 
-                    {"$group": {"_id": "$tags", "count": {"$sum": "$value"}}}, 
+                    {"$unwind": "$tags"},
+                    {"$group": {"_id": "$tags", "count": {"$sum": "$value"}}},
                     {"$sort": SON([("count", -1), ("_id", -1)])}
                 ]
             }
@@ -2022,7 +2026,7 @@ The request above will cause the aggregation to be executed on the server with
 a `count` field configured as if it was a static ``{"$sum": 2}``. The client
 simply adds the ``aggregate`` query parameter and then passes a dictionary with
 field/value pairs. Like with all other keywords, you can change ``aggregate``
-to a keyword of your liking, just set ``QUERY_AGGREGATION`` in your settings. 
+to a keyword of your liking, just set ``QUERY_AGGREGATION`` in your settings.
 
 You can also set all options natively supported by PyMongo. For more
 informations on aggregation see :ref:`datasource`.
@@ -2031,7 +2035,7 @@ Limitations
 ~~~~~~~~~~~
 ``HATEOAS`` is not available at aggregation endpoints. This should not
 be surprising as documents returned by these endpoints are aggregation results
-and do not reside on the database, so there is no static link available for them. 
+and do not reside on the database, so there is no static link available for them.
 
 Client pagination (``?page=2``) is enabled by default. This is currently
 achieved by injecting two additional stages (``$limit`` first, then ``$skip``)
@@ -2050,7 +2054,7 @@ documentation (link_):
     When a ``$sort`` immediately precedes a ``$limit`` in the pipeline, the
     sort operation only maintains the top **n** results as it progresses, where
     **n** is the specified limit, and MongoDB only needs to store **n** items
-    in memory. 
+    in memory.
 
 As we just saw earlier, pagination adds a ``$limit`` stage to the end of the
 pipeline. So if pagination is enabled and ``$sort`` is the last stage of your
@@ -2065,7 +2069,7 @@ MongoDB and SQL Support
 Support for single or multiple MongoDB database/servers comes out of the box.
 An SQLAlchemy extension provides support for SQL backends. Additional data
 layers can can be developed with relative ease. Visit the `extensions page`_
-for a list of community developed data layers and extensions. 
+for a list of community developed data layers and extensions.
 
 Powered by Flask
 ----------------
@@ -2099,6 +2103,6 @@ for unittesting_ and an `extensive documentation`_.
 .. _`Replica Set Oplog`: http://docs.mongodb.org/manual/core/replica-set-oplog/
 .. _`extensions page`: http://python-eve.org/extensions
 .. _source: http://en.wikipedia.org/wiki/JSONP
-.. _`LogRecord attributes`: https://docs.python.org/2/library/logging.html#logrecord-attributes 
+.. _`LogRecord attributes`: https://docs.python.org/2/library/logging.html#logrecord-attributes
 .. _`MongoDB Aggregation Framework`: https://docs.mongodb.org/v3.0/applications/aggregation/
 .. _link: https://docs.mongodb.org/manual/reference/operator/aggregation/limit/

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -13,6 +13,7 @@
 
     .. versionchanged:: 0.7
        'OPLOG_RETURN_EXTRA_FIELD' added and set to False.
+       'ENFORCE_IF_MATCH'added and set to True.
 
     .. versionchanged:: 0.6
        'UPSERT_ON_PUT? added and set to True.
@@ -142,6 +143,7 @@ X_ALLOW_CREDENTIALS = None      # CORS disabled by default.
 X_MAX_AGE = 21600               # Access-Control-Max-Age when CORS is enabled
 HATEOAS = True                  # HATEOAS enabled by default.
 IF_MATCH = True                 # IF_MATCH (ETag match) enabled by default.
+ENFORCE_IF_MATCH = True         # ENFORCE_IF_MATCH enabled by default.
 
 ALLOWED_FILTERS = ['*']         # filtering enabled by default
 VALIDATE_FILTERS = False

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -9,21 +9,27 @@
     :copyright: (c) 2016 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-import time
-from datetime import datetime
-
 import base64
 import simplejson as json
-from bson.errors import InvalidId
-from bson.dbref import DBRef
-from copy import copy
-from flask import current_app as app, request, abort, g, Response
-from functools import wraps
+import time
 
-from eve.utils import parse_request, document_etag, config, \
-    debug_error_message, auto_fields
-from eve.versioning import resolve_document_version, \
-    get_data_version_relation_document
+from bson.dbref import DBRef
+from bson.errors import InvalidId
+from copy import copy
+from datetime import datetime
+from eve.utils import auto_fields
+from eve.utils import config
+from eve.utils import debug_error_message
+from eve.utils import document_etag
+from eve.utils import parse_request
+from eve.versioning import get_data_version_relation_document
+from eve.versioning import resolve_document_version
+from flask import Response
+from flask import abort
+from flask import current_app as app
+from flask import g
+from flask import request
+from functools import wraps
 
 
 def get_document(resource, concurrency_check, **lookup):
@@ -60,9 +66,13 @@ def get_document(resource, concurrency_check, **lookup):
 
     document = app.data.find_one(resource, req, **lookup)
     if document:
-        if not req.if_match and config.IF_MATCH and concurrency_check:
+        e_if_m = config.ENFORCE_IF_MATCH
+        if_m = config.IF_MATCH
+        if not req.if_match and e_if_m and if_m and concurrency_check:
             # we don't allow editing unless the client provides an etag
-            # for the document
+            # for the document or explicitly decides to allow editing by either
+            # disabling the ``concurrency_check`` or ``IF_MATCH`` or
+            # ``ENFORCE_IF_MATCH`` fields.
             abort(428, description='To edit a document '
                   'its etag must be provided using the If-Match header')
 

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -1,12 +1,15 @@
-from bson import ObjectId
 import simplejson as json
 
+from bson import ObjectId
+from eve import ETAG
+from eve import ISSUES
+from eve import LAST_UPDATED
+from eve import STATUS
+from eve import STATUS_OK
+from eve.methods.patch import patch_internal
 from eve.tests import TestBase
 from eve.tests.test_settings import MONGO_DBNAME
 from eve.tests.utils import DummyEvent
-
-from eve import STATUS_OK, LAST_UPDATED, ISSUES, STATUS, ETAG
-from eve.methods.patch import patch_internal
 
 
 class TestPatch(TestBase):
@@ -46,7 +49,20 @@ class TestPatch(TestBase):
         res, status = self.patch(self.item_id_url, data={'key1': 'value1'})
         self.assert428(status)
 
+    def test_ifmatch_missing_enforce_ifmatch_disabled(self):
+        self.app.config['ENFORCE_IF_MATCH'] = False
+        r, status = self.patch(self.item_id_url, data={'key1': 'value1'})
+        self.assert200(status)
+        self.assertTrue(ETAG in r)
+
     def test_ifmatch_disabled(self):
+        self.app.config['IF_MATCH'] = False
+        r, status = self.patch(self.item_id_url, data={'key1': 'value1'})
+        self.assert200(status)
+        self.assertTrue(ETAG not in r)
+
+    def test_ifmatch_disabled_enforce_ifmatch_disabled(self):
+        self.app.config['ENFORCE_IF_MATCH'] = False
         self.app.config['IF_MATCH'] = False
         r, status = self.patch(self.item_id_url, data={'key1': 'value1'})
         self.assert200(status)
@@ -58,12 +74,19 @@ class TestPatch(TestBase):
                                headers=[('If-Match', 'not-quite-right')])
         self.assert412(status)
 
+    def test_ifmatch_bad_etag_enforce_ifmatch_disabled(self):
+        self.app.config['ENFORCE_IF_MATCH'] = False
+        _, status = self.patch(self.item_id_url,
+                               data={'key1': 'value1'},
+                               headers=[('If-Match', 'not-quite-right')])
+        self.assert412(status)
+
     def test_unique_value(self):
         # TODO
         # for the time being we are happy with testing only Eve's custom
         # validation. We rely on Cerberus' own test suite for other validation
         # unit tests. This test also makes sure that response status is
-        # syntatically correcy in case of validation issues.
+        # syntatically correct in case of validation issues.
         # We should probably test every single case as well (seems overkill).
         r, status = self.patch(self.item_id_url,
                                data={"ref": "%s" % self.alt_ref},
@@ -202,7 +225,7 @@ class TestPatch(TestBase):
         self.assert200(status)
 
     def test_patch_etag_header(self):
-        # test that Etag is always includer with response header. See #562.
+        # test that Etag is always included with response header. See #562.
         changes = {"ref": "1234567890123456789012345"}
         headers = [('Content-Type', 'application/json'),
                    ('If-Match', self.item_etag)]
@@ -216,6 +239,20 @@ class TestPatch(TestBase):
 
         self.assertTrue(etag[0] == '"')
         self.assertTrue(etag[-1] == '"')
+
+    def test_patch_etag_header_enforce_ifmatch_disabled(self):
+        self.app.config['ENFORCE_IF_MATCH'] = False
+        changes = {'ref': '1234567890123456789012345'}
+        headers = [('Content-Type', 'application/json'),
+                   ('If-Match', self.item_etag)]
+        r, status = self.patch(
+            self.item_id_url,
+            data=json.dumps(changes),
+            headers=headers
+        )
+
+        self.assertTrue(ETAG in r)
+        self.assertTrue(self.item_etag != r[ETAG])
 
     def test_patch_nested(self):
         changes = {'location.city': 'a nested city',


### PR DESCRIPTION
If `ENFORCE_IF_MATCH` is disabled and `IF_MATCH` is enabled, then
the client can choose whether to provide the `If-Match` header in
its request. When `If-Match` is provided, then the request is treated as
conditional, meaning the ETag must match. When `If-Match` is absent,
then the ETag check is not enforced.

The `ENFORCE_IF_MATCH` flag defaults to `True`

Closes #657