### PR TITLE
Added unit test for issue 810.

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -1040,6 +1040,8 @@ def resource_link():
     """
     path = request.path.strip('/')
 
+    assert request.routing_exception is None, 'Routing error for %s: %s' % (request.url, request.routing_exception)
+
     if '|item' in request.endpoint:
         path = path[:path.rfind('/')]
 

--- a/eve/tests/endpoints.py
+++ b/eve/tests/endpoints.py
@@ -218,6 +218,27 @@ class TestEndPoints(TestBase):
         r = self.test_prefix.get('/prefix/contacts/')
         self.assert200(r.status_code)
 
+        r = self.test_prefix.post('/prefix/contacts/', data='{}',
+                                  content_type='application/json')
+        self.assert201(r.status_code)
+
+    def test_api_prefix_post_internal(self):
+        from eve.methods.post import post_internal
+
+        settings_file = os.path.join(self.this_directory, 'test_prefix.py')
+        self.app = Eve(settings=settings_file)
+        self.test_prefix = self.app.test_client()
+
+        # This works fine
+        with self.app.test_request_context(method='POST', path='/prefix/contacts'):
+            r, _, _, status_code = post_internal('contacts', {})
+        self.assert201(status_code)
+
+        # This fails
+        with self.app.test_request_context():
+            r, _, _, status_code = post_internal('contacts', {})
+        self.assert201(status_code)
+
     def test_api_prefix_version(self):
         settings_file = os.path.join(self.this_directory,
                                      'test_prefix_version.py')

--- a/eve/tests/test_prefix.py
+++ b/eve/tests/test_prefix.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+RESOURCE_METHODS = ['GET', 'POST']
 URL_PREFIX = 'prefix'
 DOMAIN = {'contacts': {}}


### PR DESCRIPTION
The problem with #810 seems to be that code called by post_internal() relies on the Flask `request` object, even though the current request may not be a POST to the given resource. I'm not sure how to fix this myself, though.
