### PR TITLE
Import PyMongo Flask extension directly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -133,3 +133,4 @@ Patches and Contributions
 - dccrazyboy
 - mmizotin
 - xgdgsc
+- George Lestaris

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -19,7 +19,7 @@ from bson import ObjectId
 from bson.dbref import DBRef
 from copy import copy
 from flask import abort, request, g
-from flask.ext.pymongo import PyMongo
+from flask_pymongo import PyMongo
 from pymongo import WriteConcern
 from werkzeug.exceptions import HTTPException
 

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -7,7 +7,7 @@ import random
 import os
 import simplejson as json
 from datetime import datetime, timedelta
-from flask.ext.pymongo import MongoClient
+from flask_pymongo import MongoClient
 from bson import ObjectId
 from eve.tests.test_settings import MONGO_PASSWORD, MONGO_USERNAME, \
     MONGO_DBNAME, DOMAIN, MONGO_HOST, MONGO_PORT

--- a/eve/tests/io/multi_mongo.py
+++ b/eve/tests/io/multi_mongo.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import json
 from bson import ObjectId
-from flask.ext.pymongo import MongoClient
+from flask_pymongo import MongoClient
 
 import eve
 from eve.auth import BasicAuth


### PR DESCRIPTION
Importing Flask extensions vie `flask.ext` is deprecated.

Close #898.