### PR TITLE
Added MONGO_OPTIONS config to pass keyword arguments to MongoClient.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -497,6 +497,10 @@ uppercase.
 ``MONGO_URI``                       A `MongoDB URI`_ which is used in preference
                                     of the other configuration variables.
 
+``MONGO_OPTIONS``                   MongoDB keyword arguments to passed to
+                                    MongoClient class ``__init__``.
+                                    Defaults to ``{}``.
+
 ``MONGO_HOST``                      MongoDB server address. Defaults to ``localhost``.
 
 ``MONGO_PORT``                      MongoDB port. Defaults to ``27017``.

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -959,7 +959,8 @@ def create_index(app, resource, name, list_of_keys, index_options):
     collection = app.config['SOURCES'][resource]['source']
 
     if 'MONGO_URI' in app.config and app.config['MONGO_URI']:
-        conn = pymongo.MongoClient(app.config['MONGO_URI'])
+        mongo_options = app.config.get('MONGO_OPTIONS', {})
+        conn = pymongo.MongoClient(app.config['MONGO_URI'], **mongo_options)
         db = conn.get_default_database()
     else:
         config_prefix = app.config['DOMAIN'][resource].get('mongo_prefix',
@@ -983,7 +984,8 @@ def create_index(app, resource, name, list_of_keys, index_options):
         port = app.config[key('PORT')]
         auth = (username, password)
         host_and_port = '%s:%s' % (host, port)
-        conn = pymongo.MongoClient(host_and_port)
+        mongo_options = app.config.get(key('OPTIONS'), {})
+        conn = pymongo.MongoClient(host_and_port, **mongo_options)
         db = conn[db_name]
 
         if any(auth):


### PR DESCRIPTION
Added MONGO_OPTIONS config to pass additional keyword arguments to [MongoClient](http://api.mongodb.com/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient)