### PR TITLE
Fix validation for multipart/form-data Lists #915

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,6 +91,7 @@ Patches and Contributions
 - Mayur Dhamanwala
 - Mikael Berg
 - Mugur Rus
+- Namgyal Brisson
 - Nathan Reynolds
 - Niall Donegan
 - Nick Park


### PR DESCRIPTION
Hi Nicola,

First, I've seen your work about `MULTIPART_FORM_FIELDS_AS_JSON` option and that's great!
In the same intention, this PR to allow one who follows convention about `multipart/form-data` list type to send its data in a way Eve schema validation step will understand.

I hope I did not forget any Use Case, your feedback is welcomed :)
