### PR TITLE
Escape the resource title in the XML render of the root doc

### DIFF
--- a/eve/render.py
+++ b/eve/render.py
@@ -376,8 +376,8 @@ def xml_add_links(data):
     ordered_links = OrderedDict(sorted(links.items()))
     for rel, link in ordered_links.items():
         if isinstance(link, list):
-            xml += ''.join([chunk % (rel, utils.escape(d['href']), utils.escape(d['title']))
-                            for d in link])
+            xml += ''.join([chunk % (rel, utils.escape(d['href']),
+                            utils.escape(d['title'])) for d in link])
         else:
             xml += ''.join(chunk % (rel, utils.escape(link['href']),
                                     link['title']))

--- a/eve/render.py
+++ b/eve/render.py
@@ -376,7 +376,7 @@ def xml_add_links(data):
     ordered_links = OrderedDict(sorted(links.items()))
     for rel, link in ordered_links.items():
         if isinstance(link, list):
-            xml += ''.join([chunk % (rel, utils.escape(d['href']), d['title'])
+            xml += ''.join([chunk % (rel, utils.escape(d['href']), utils.escape(d['title']))
                             for d in link])
         else:
             xml += ''.join(chunk % (rel, utils.escape(link['href']),


### PR DESCRIPTION
In the XML render of the root doc we are already escaping the href, but not the resource title. This patch adds escaping to the resource title.

This issue is particularly easy to hit when setting up Sub Resources as by default the the resource_title = url which shall contain characters that need to be escaped in XML.