### PR TITLE
Allowed headers for CORS preflight responses

### DIFF
--- a/eve/render.py
+++ b/eve/render.py
@@ -141,6 +141,10 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
     """
     if request.method == 'OPTIONS':
         resp = app.make_default_options_response()
+        
+        # return a default response including the allowed_headers (X_HEADERS)
+        allowed_headers =  (", ".join(config.X_HEADERS))
+        resp.headers.add('Access-Control-Allow-Headers', allowed_headers)
     else:
         # obtain the best match between client's request and available mime
         # types, along with the corresponding render function.


### PR DESCRIPTION
Adds the Access-Control-Allow-Headers for CORS preflight responses using X_HEADERS definition.

With this change, a CORS preflight will be answered with the needed headers:
HTTP/1.1 200 OK
Server: XXX
Date: Thu, 13 Oct 2016 17:04:19 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: keep-alive
Allow: HEAD, GET, OPTIONS, POST, DELETE
Access-Control-Allow-Origin: XXX
**access-control-allow-headers: $X_HEADERS_CONTENT**

Fix issue #921
