### PR TITLE
Add Python 3.5 as a supported interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=pypy
-  - TOX_ENV=flake8
 install: pip install tox
-script: 
-  - tox -e $TOX_ENV
-services: 
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py26
+    - python: 2.7
+      env: TOX_ENV=py27
+    - python: 2.7
+      env: TOX_ENV=py33
+    - python: 2.7
+      env: TOX_ENV=py34
+    - python: 2.7
+      env: TOX_ENV=pypy
+    - python: 2.7
+      env: TOX_ENV=flake8
+    - python: 3.5
+      env: TOX_ENV=py35
+script:
+    - tox -e $TOX_ENV
+services:
   - mongodb
   - redis-server
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ RESTful Web Services.
 Eve is powered by Flask, Redis, Cerberus, Events and offers support for both
 MongoDB and SQL backends.
 
-The codebase is thoroughly tested under Python 2.6, 2.7, 3.3, 3.4 and PyPy.
+The codebase is thoroughly tested under Python 2.6, 2.7, 3.3, 3.4, 3.5 and PyPy.
 
 Eve is Simple
 -------------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ Pygments==2.0.1
 pytest==2.6.4
 redis==2.10.3
 Sphinx==1.2.3
-tox==1.8.1
+tox==2.4.1
 wheel==0.24.0
 testfixtures==4.1.2
 -e git+https://github.com/nicolaiarocci/alabaster.git@15d190f29f86141aab202843f2bf3edfde71e56c#egg=al

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Eve is powered by Flask_, Cerberus_, Events_ and MongoDB_. Support for
 SQL-Alchemy, Elasticsearch and Neo4js as alternate backends is provided by
 community extensions_. 
 
-The codebase is thoroughly tested under Python 2.6, 2.7, 3.3, 3.4 and PyPy.
+The codebase is thoroughly tested under Python 2.6, 2.7, 3.3, 3.4, 3.5 and PyPy.
 
 Eve is Simple
 -------------

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -48,7 +48,7 @@ by running ::
 Testing with other python versions
 ----------------------------------
 Before you submit a pull request, make sure your tests and changes run in
-all supported python versions: 2.6, 2.7, 3.3, 3.4 and PyPy. Instead of creating all
+all supported python versions: 2.6, 2.7, 3.3, 3.4, 3.5 and PyPy. Instead of creating all
 those environments by hand, Eve uses tox_.
 
 Make sure you have all required python versions installed and run:
@@ -69,6 +69,7 @@ the following:
     py27: commands succeeded
     py33: commands succeeded
     py34: commands succeeded
+    py35: commands succeeded
     pypy: commands succeeded
     flake8: commands succeeded
     congratulations :)

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -483,7 +483,8 @@ class Mongo(DataLayer):
                 self.driver.db.client.server_info()['version'][:3]
             if (
                 (server_version == '2.4' and e.code in (13596, 10148)) or
-                (server_version in ('2.6', '3.0') and e.code in (66, 16837))
+                (server_version in ('2.6', '3.0', '3.2') and
+                    e.code in (66, 16837))
             ):
                 # attempt to update an immutable field. this usually
                 # happens when a PATCH or PUT includes a mismatching ID_FIELD.

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,pypy,flake8
+envlist=py26,py27,py33,py34,py35,pypy,flake8
 
 [testenv]
 commands=python setup.py test {posargs}


### PR DESCRIPTION
Add Python 3.5 as a supported interpreter in documentation and enables travis running of tests on Python 3.5.

To get everything working and upgrade of tox was needed in the dev requirements (travis already installed the latest version).

To get the tests running locally on my machine (Arch linux running Python 3.5.2) I needed to modify handling of attempts to modify immutables in `eve/io/mongo/mongo.py`. I suspect that this is the version of MongoDB used locally (3.2.9), but not sure about why I need to do the change (tests are passing in all other Python versions).