### PR TITLE
Added serialization rule for boolean

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -80,6 +80,8 @@ class Mongo(DataLayer):
         'integer': lambda value: int(value) if value is not None else None,
         'float': lambda value: float(value) if value is not None else None,
         'number': lambda val: json.loads(val) if val is not None else None,
+        'boolean': lambda v:
+        {'1': True, 'true': True, '0': False, 'false': False}[str(v).lower()],
         'dbref': lambda value:
         DBRef(value['$col'], value['$id'], value['$db']
               if '$db' in value else None) if value is not None else None,

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -305,6 +305,15 @@ class TestSerializer(TestBase):
                     isinstance(serialized['anumber'], expected_type)
                 )
 
+    def test_serialize_boolean(self):
+        schema = {'bool': {'type': 'boolean'}}
+
+        with self.app.app_context():
+            for val in [1, '1', 0, '0', 'true', 'True', 'false', 'False']:
+                doc = {'bool': val}
+                serialized = serialize(doc, schema=schema)
+                self.assertTrue(isinstance(serialized['bool'], bool))
+
     def test_serialize_inside_x_of_rules(self):
         for x_of in ['allof', 'anyof', 'oneof', 'noneof']:
             schema = {


### PR DESCRIPTION
A range of values is now serialized to boolean, namely:

0, 1, '0', '1', 'false', 'False', 'true', 'True'

This covers the most common boolean inputs.

Closes #947 